### PR TITLE
Support for REPL CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,23 @@ Current list of maintained releases:
 - not supported: -
 
 
+0.3.0 (2022-08-22)
+------------------
+
+Upgrade urgency: LOW; new CLI and common functionality
+
+- Add sample project to show capabilities of REPL CLI tooling
+- Add tooling for building iteractive REPL (Read-eval-print loop)
+  CLI (command line interface) program. Supported features includ
+  progress indicators as well as scaffold for commands.
+  See sample projects for examples.
+- Add new extensions and parsing functionality including:
+  string parameter line check, new string and binary dumps,
+  new time related extensions, looping collection,
+  tokenizers and parsers, string literal functionality,
+  support for simple markdown for CLI, better progress class.
+
+
 0.2.0 (2022-07-13)
 ------------------
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,7 @@
 
             PackageVersion is auto-set when packing.
         -->
-        <Version>0.2.0</Version>
+        <Version>0.3.0</Version>
         <PackageProjectUrl>https://github.com/jozefsivek/radicle.cs</PackageProjectUrl>
         <PackageReleaseNotes>https://github.com/jozefsivek/radicle.cs/blob/master/CHANGELOG.md</PackageReleaseNotes>
     </PropertyGroup>

--- a/samples/Radicle.Sample.CLI/Evaluators/Base/CommandEvaluator.cs
+++ b/samples/Radicle.Sample.CLI/Evaluators/Base/CommandEvaluator.cs
@@ -1,0 +1,17 @@
+﻿namespace Radicle.Sample.CLI.Evaluators.Base;
+
+using Radicle.CLI.Evaluators.Base;
+using Radicle.CLI.Models;
+
+/// <summary>
+/// Base class of sample evaluators.
+/// </summary>
+internal abstract class CommandEvaluator : CommandEvaluator<EvaluationOutput, SampleREPLEvaluator>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CommandEvaluator"/> class.
+    /// </summary>
+    internal CommandEvaluator()
+    {
+    }
+}

--- a/samples/Radicle.Sample.CLI/Evaluators/EchoEvaluator.cs
+++ b/samples/Radicle.Sample.CLI/Evaluators/EchoEvaluator.cs
@@ -1,0 +1,67 @@
+﻿namespace Radicle.Sample.CLI.Evaluators;
+
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Radicle.CLI.Evaluators;
+using Radicle.CLI.Models;
+using Radicle.Common;
+using Radicle.Common.Tokenization.Models;
+using Radicle.Sample.CLI.Evaluators.Base;
+
+/// <summary>
+/// "ECHO" command evaluator.
+/// </summary>
+internal sealed class EchoEvaluator : CommandEvaluator
+{
+    /// <summary>
+    /// Main verb of this command evaluator.
+    /// </summary>
+    public static readonly CommandVerb MainVerb = new("ECHO");
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EchoEvaluator"/> class.
+    /// </summary>
+    public EchoEvaluator()
+    {
+    }
+
+    /// <inheritdoc/>
+    public override ICommandGroup Group => SampleGroup.Instance;
+
+    /// <inheritdoc/>
+    public override CommandVerb Verb => MainVerb;
+
+    /// <inheritdoc/>
+    public override string ArgumentsDocTemplate =>
+            "[argument ...]";
+
+    /// <inheritdoc/>
+    public override string Summary =>
+            "Returns command evaluator arguments back as they were used in the call";
+
+    /// <inheritdoc/>
+    public override string Since => "0.3.0";
+
+    /// <inheritdoc/>
+    public override string TimeComplexityDoc => "O(1)";
+
+    /// <inheritdoc/>
+    protected override Task<EvaluationOutput> EvaluateArgsAsync(
+            SampleREPLEvaluator context,
+            TokenWithValue[] arguments,
+            TransparentProgress<long>? progress = null,
+            CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(EvaluationOutput.SuccessFrom(OutputLine.ToOutputLines(arguments.Select(a => Dump.Literal(a)))));
+    }
+
+    /// <inheritdoc/>
+    protected override Task<EvaluationOutput> EvaluateEmptyAsync(
+            SampleREPLEvaluator context,
+            TransparentProgress<long>? progress,
+            CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(EvaluationOutput.SuccessFrom());
+    }
+}

--- a/samples/Radicle.Sample.CLI/Evaluators/FooBarEvaluator.cs
+++ b/samples/Radicle.Sample.CLI/Evaluators/FooBarEvaluator.cs
@@ -1,0 +1,65 @@
+﻿namespace Radicle.Sample.CLI.Evaluators;
+
+using System.Threading;
+using System.Threading.Tasks;
+using Radicle.CLI.Evaluators;
+using Radicle.CLI.Models;
+using Radicle.Common;
+using Radicle.Common.Tokenization.Models;
+using Radicle.Sample.CLI.Evaluators.Base;
+
+/// <summary>
+/// "FOO BAR" command evaluator.
+/// </summary>
+internal sealed class FooBarEvaluator : CommandEvaluator
+{
+    /// <summary>
+    /// Main verb of this command evaluator.
+    /// </summary>
+    public static readonly CommandVerb MainVerb = /*FOO*/ new("BAR");
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FooBarEvaluator"/> class.
+    /// </summary>
+    public FooBarEvaluator()
+    {
+    }
+
+    /// <inheritdoc/>
+    public override ICommandGroup Group => SampleGroup.Instance;
+
+    /// <inheritdoc/>
+    public override CommandVerb Verb => MainVerb;
+
+    /// <inheritdoc/>
+    public override string ArgumentsDocTemplate => "-";
+
+    /// <inheritdoc/>
+    public override string Summary =>
+            "example of command nesting";
+
+    /// <inheritdoc/>
+    public override string Since => "0.3.0";
+
+    /// <inheritdoc/>
+    public override string TimeComplexityDoc => "O(1)";
+
+    /// <inheritdoc/>
+    protected override Task<EvaluationOutput> EvaluateArgsAsync(
+            SampleREPLEvaluator context,
+            TokenWithValue[] arguments,
+            TransparentProgress<long>? progress = null,
+            CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(EvaluationOutput.SuccessFrom($"OK bar [{arguments.Length}]"));
+    }
+
+    /// <inheritdoc/>
+    protected override Task<EvaluationOutput> EvaluateEmptyAsync(
+            SampleREPLEvaluator context,
+            TransparentProgress<long>? progress,
+            CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(EvaluationOutput.SuccessFrom("OK bar"));
+    }
+}

--- a/samples/Radicle.Sample.CLI/Evaluators/FooEvaluator.cs
+++ b/samples/Radicle.Sample.CLI/Evaluators/FooEvaluator.cs
@@ -1,0 +1,72 @@
+﻿namespace Radicle.Sample.CLI.Evaluators;
+
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Radicle.CLI.Evaluators;
+using Radicle.CLI.Evaluators.Generic;
+using Radicle.CLI.Models;
+using Radicle.Common;
+using Radicle.Common.Tokenization.Models;
+using Radicle.Sample.CLI.Evaluators.Base;
+
+/// <summary>
+/// "FOO" command evaluator.
+/// </summary>
+internal sealed class FooEvaluator : CommandEvaluator
+{
+    /// <summary>
+    /// Main verb of this command evaluator.
+    /// </summary>
+    public static readonly CommandVerb MainVerb = new("FOO");
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FooEvaluator"/> class.
+    /// </summary>
+    public FooEvaluator()
+    {
+        this.Subs = new ICommandEvaluator<EvaluationOutput, SampleREPLEvaluator>[]
+        {
+            new FooBarEvaluator(),
+        }.ToImmutableArray();
+    }
+
+    /// <inheritdoc/>
+    public override ICommandGroup Group => SampleGroup.Instance;
+
+    /// <inheritdoc/>
+    public override CommandVerb Verb => MainVerb;
+
+    /// <inheritdoc/>
+    public override string ArgumentsDocTemplate =>
+            "[BAR]";
+
+    /// <inheritdoc/>
+    public override string Summary =>
+            "example of command nesting";
+
+    /// <inheritdoc/>
+    public override string Since => "0.3.0";
+
+    /// <inheritdoc/>
+    public override string TimeComplexityDoc => "O(1)";
+
+    /// <inheritdoc/>
+    protected override Task<EvaluationOutput> EvaluateArgsAsync(
+            SampleREPLEvaluator context,
+            TokenWithValue[] arguments,
+            TransparentProgress<long>? progress = null,
+            CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(EvaluationOutput.SuccessFrom($"OK foo [{arguments.Length}]"));
+    }
+
+    /// <inheritdoc/>
+    protected override Task<EvaluationOutput> EvaluateEmptyAsync(
+            SampleREPLEvaluator context,
+            TransparentProgress<long>? progress,
+            CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(EvaluationOutput.SuccessFrom("OK foo"));
+    }
+}

--- a/samples/Radicle.Sample.CLI/Evaluators/HelpEvaluator.cs
+++ b/samples/Radicle.Sample.CLI/Evaluators/HelpEvaluator.cs
@@ -1,0 +1,224 @@
+namespace Radicle.Sample.CLI.Evaluators;
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Radicle.CLI.Evaluators;
+using Radicle.CLI.Models;
+using Radicle.Common;
+using Radicle.Common.Tokenization.Models;
+using Radicle.Sample.CLI.Evaluators.Base;
+
+// TODO: see Redis "COMMAND DOCS"
+
+/// <summary>
+/// "HELP" command evaluator.
+/// </summary>
+internal sealed class HelpEvaluator : CommandEvaluator
+{
+    /// <summary>
+    /// Main verb of this command evaluator.
+    /// </summary>
+    public static readonly CommandVerb MainVerb = new("HELP");
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HelpEvaluator"/> class.
+    /// </summary>
+    public HelpEvaluator()
+    {
+        this.VerbSynonyms = new[] { new CommandVerbSynonym("?") }.ToImmutableHashSet();
+    }
+
+    /// <inheritdoc/>
+    public override ICommandGroup Group => SampleGroup.Instance;
+
+    /// <inheritdoc/>
+    public override CommandVerb Verb => MainVerb;
+
+    /// <inheritdoc/>
+    public override string ArgumentsDocTemplate =>
+            "[command [subcommand ...]|@<group_name>|@all]";
+
+    /// <inheritdoc/>
+    public override string Summary =>
+            "Prints general help or help for specific command";
+
+    /// <inheritdoc/>
+    public override string Since => "0.3.0";
+
+    /// <inheritdoc/>
+    public override string TimeComplexityDoc =>
+            "O(N) where N is amount of the commands matching input criteria";
+
+    /// <inheritdoc/>
+    protected override Task<EvaluationOutput> EvaluateEmptyAsync(
+            SampleREPLEvaluator context,
+            TransparentProgress<long>? progress,
+            CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(EvaluationOutput.SuccessFrom(SimpleMarkdownText.FromStrings(new[]
+        {
+                "To get help about Radicle sample CLI commands, type the following:",
+                "      _\"help|?\"_ show this help",
+                "      _\"help|? <command>\"_ show help on <command>",
+                "      _\"help @all\"_ list all available commands",
+                "      _\"help @<group_name>\"_ list all available commands in the given group",
+                "      _\"quit|q\"_ exit",
+        })));
+    }
+
+    /// <inheritdoc/>
+    protected override Task<EvaluationOutput> EvaluateArgsAsync(
+            SampleREPLEvaluator context,
+            TokenWithValue[] arguments,
+            TransparentProgress<long>? progress,
+            CancellationToken cancellationToken = default)
+    {
+        string[] args = new string[arguments.Length];
+
+        for (int i = 0; i < arguments.Length; i++)
+        {
+            if (arguments[i] is TokenString ts)
+            {
+                args[i] = ts.StringValue;
+            }
+            else
+            {
+                return Task.FromResult(EvaluationOutput.ErrorFrom(
+                        $"Not supported arguments for '{this.Verb.DocName}' command."));
+            }
+        }
+
+        // check groups
+        if (args[0].StartsWith('@'))
+        {
+            if (args.Length != 1)
+            {
+                return Task.FromResult(EvaluationOutput.ErrorFrom(
+                        $"Wrong number of arguments for '{this.Verb.DocName}' command."));
+            }
+
+            string rawGroupName = args[0][1..];
+
+            if (rawGroupName.Equals("all", StringComparison.OrdinalIgnoreCase))
+            {
+                return Task.FromResult(EvaluationOutput.SuccessFrom(HelpOutput(
+                            false,
+                            context.Commands.GetAllListed(recursive: true))));
+            }
+            else if (CommandGroupName.Specification.IsValid(rawGroupName))
+            {
+                CommandGroupName groupName = new(rawGroupName);
+
+                return Task.FromResult(EvaluationOutput.SuccessFrom(HelpOutput(
+                            false,
+                            context.Commands.GetByGroup(groupName, recursive: true))));
+            }
+            else
+            {
+                return Task.FromResult(EvaluationOutput.SuccessFrom());
+            }
+        }
+        else if (context.Commands.TryGetByVerbOrSynonym(
+                args, out CommandEvaluatorRecord? record))
+        {
+            return Task.FromResult(EvaluationOutput.SuccessFrom(HelpOutput(true, record)));
+        }
+
+        return Task.FromResult(EvaluationOutput.SilentError);
+    }
+
+    private static IEnumerable<SimpleMarkdownText> HelpOutput(
+            bool extended,
+            params CommandEvaluatorRecord[] records)
+    {
+        return HelpOutput(
+                extended,
+                records as IEnumerable<CommandEvaluatorRecord>);
+    }
+
+    private static IEnumerable<SimpleMarkdownText> HelpOutput(
+            bool extended,
+            IEnumerable<CommandEvaluatorRecord> records)
+    {
+        foreach (CommandEvaluatorRecord record in records)
+        {
+            yield return string.Empty;
+
+            foreach (SimpleMarkdownText text in
+                    SingleHelpOutput(extended, record))
+            {
+                yield return text;
+            }
+        }
+
+        yield return string.Empty;
+    }
+
+    private static IEnumerable<SimpleMarkdownText> SingleHelpOutput(
+            bool extended,
+            CommandEvaluatorRecord record)
+    {
+        ICommandEvaluator evaluator = record.Evaluator;
+        string sanitized = SimpleMarkdownText.Sanitize(evaluator.ArgumentsDocTemplate).Value;
+        string compoundVerb = evaluator.Verb.DocName;
+
+        if (record.Ancestors.Length > 0)
+        {
+            compoundVerb = new StringBuilder()
+                    .AppendJoin(' ', record.Ancestors.Select(i => i.Evaluator.Verb.DocName))
+                    .Append(' ')
+                    .Append(compoundVerb)
+                    .ToString();
+        }
+
+        yield return $"  {compoundVerb} _{sanitized}_";
+
+        if (extended)
+        {
+            yield return $"  *complexity*: {SimpleMarkdownText.Sanitize(evaluator.TimeComplexityDoc)}";
+        }
+
+        yield return $"  *summary*: {SimpleMarkdownText.Sanitize(evaluator.Summary)}";
+        yield return $"  *since*: {SimpleMarkdownText.Sanitize(evaluator.Since)}";
+
+        if (extended)
+        {
+            if (evaluator.ChangeLog.Count > 0)
+            {
+                yield return "  *changelog*:";
+
+                foreach (KeyValuePair<string, SimpleMarkdownText> item in evaluator.ChangeLog)
+                {
+                    yield return $"    _{SimpleMarkdownText.Sanitize(item.Key)}_: {item.Value}";
+                }
+            }
+
+            if (evaluator.Doc.Length > 0)
+            {
+                yield return "  *documentation*:";
+
+                foreach (SimpleMarkdownText text in evaluator.Doc)
+                {
+                    yield return $"  {text}";
+                }
+            }
+        }
+
+        yield return $"  *group*: {SimpleMarkdownText.Sanitize(evaluator.Group.Name.InvariantValue)}";
+
+        if (evaluator.IsLegacy)
+        {
+            yield return "  *legacy*: this command will be removed in future releases";
+        }
+
+        if (evaluator.IsExperimental)
+        {
+            yield return "  *experimantal*: this command is experimental, use with caution, can change";
+        }
+    }
+}

--- a/samples/Radicle.Sample.CLI/Evaluators/HistoryEvaluator.cs
+++ b/samples/Radicle.Sample.CLI/Evaluators/HistoryEvaluator.cs
@@ -1,0 +1,78 @@
+﻿namespace Radicle.Sample.CLI.Evaluators;
+
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Radicle.CLI.Evaluators;
+using Radicle.CLI.Models;
+using Radicle.CLI.REPL;
+using Radicle.Common;
+using Radicle.Common.Tokenization.Models;
+using Radicle.Sample.CLI.Evaluators.Base;
+
+/// <summary>
+/// "HISTORY" command evaluator.
+/// </summary>
+internal sealed class HistoryEvaluator : CommandEvaluator
+{
+    /// <summary>
+    /// Main verb of this command evaluator.
+    /// </summary>
+    public static readonly CommandVerb MainVerb = new("HISTORY");
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HistoryEvaluator"/> class.
+    /// </summary>
+    public HistoryEvaluator()
+    {
+    }
+
+    /// <inheritdoc/>
+    public override ICommandGroup Group => SampleGroup.Instance;
+
+    /// <inheritdoc/>
+    public override CommandVerb Verb => MainVerb;
+
+    /// <inheritdoc/>
+    public override string ArgumentsDocTemplate =>
+            "-";
+
+    /// <inheritdoc/>
+    public override string Summary =>
+            "Prints input history stack";
+
+    /// <inheritdoc/>
+    public override string Since => "0.3.0";
+
+    /// <inheritdoc/>
+    public override string TimeComplexityDoc =>
+            "O(N) where N is length of history stack";
+
+    /// <inheritdoc/>
+    protected override Task<EvaluationOutput> EvaluateEmptyAsync(
+            SampleREPLEvaluator context,
+            TransparentProgress<long>? progress,
+            CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(
+                EvaluationOutput.SuccessFrom(
+                    OutputLine.ToOutputLines(
+                        context.History.Select(r => RecordToString(r)))));
+    }
+
+    /// <inheritdoc/>
+    protected override Task<EvaluationOutput> EvaluateArgsAsync(
+            SampleREPLEvaluator context,
+            TokenWithValue[] arguments,
+            TransparentProgress<long>? progress,
+            CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(EvaluationOutput.ErrorFrom(
+                $"Wrong number of arguments for '{this.Verb.DocName}' command."));
+    }
+
+    private static string RecordToString(REPLInputHistoryRecord record)
+    {
+        return (record.IsModified ? "*" : " ") + record.Value;
+    }
+}

--- a/samples/Radicle.Sample.CLI/Evaluators/QuitEvaluator.cs
+++ b/samples/Radicle.Sample.CLI/Evaluators/QuitEvaluator.cs
@@ -1,0 +1,71 @@
+﻿namespace Radicle.Sample.CLI.Evaluators;
+
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Radicle.CLI.Evaluators;
+using Radicle.CLI.Models;
+using Radicle.Common;
+using Radicle.Common.Tokenization.Models;
+using Radicle.Sample.CLI.Evaluators.Base;
+
+/// <summary>
+/// "QUIT" command evaluator.
+/// </summary>
+internal sealed class QuitEvaluator : CommandEvaluator
+{
+    /// <summary>
+    /// Main verb of this command evaluator.
+    /// </summary>
+    public static readonly CommandVerb MainVerb = new("QUIT");
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="QuitEvaluator"/> class.
+    /// </summary>
+    public QuitEvaluator()
+    {
+        this.VerbSynonyms = new[]
+        {
+            new CommandVerbSynonym("EXIT"),
+            new CommandVerbSynonym("Q"),
+        }.ToImmutableHashSet();
+    }
+
+    /// <inheritdoc/>
+    public override ICommandGroup Group => SampleGroup.Instance;
+
+    /// <inheritdoc/>
+    public override CommandVerb Verb => MainVerb;
+
+    /// <inheritdoc/>
+    public override string ArgumentsDocTemplate => "-";
+
+    /// <inheritdoc/>
+    public override string Summary =>
+            "Quits program";
+
+    /// <inheritdoc/>
+    public override string Since => "0.3.0";
+
+    /// <inheritdoc/>
+    public override string TimeComplexityDoc => "O(1)";
+
+    /// <inheritdoc/>
+    protected override Task<EvaluationOutput> EvaluateArgsAsync(
+            SampleREPLEvaluator context,
+            TokenWithValue[] arguments,
+            TransparentProgress<long>? progress = null,
+            CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(EvaluationOutput.Exit);
+    }
+
+    /// <inheritdoc/>
+    protected override Task<EvaluationOutput> EvaluateEmptyAsync(
+            SampleREPLEvaluator context,
+            TransparentProgress<long>? progress,
+            CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(EvaluationOutput.Exit);
+    }
+}

--- a/samples/Radicle.Sample.CLI/Evaluators/SampleGroup.cs
+++ b/samples/Radicle.Sample.CLI/Evaluators/SampleGroup.cs
@@ -1,0 +1,24 @@
+namespace Radicle.Sample.CLI.Evaluators;
+
+using Radicle.CLI.Evaluators;
+
+/// <summary>
+/// Sample group.
+/// </summary>
+public sealed class SampleGroup : ICommandGroup
+{
+    /// <summary>
+    /// Static singeton instance of this class.
+    /// </summary>
+    public static readonly SampleGroup Instance = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SampleGroup"/> class.
+    /// </summary>
+    private SampleGroup()
+    {
+    }
+
+    /// <inheritdoc/>
+    public CommandGroupName Name { get; } = new CommandGroupName("sample");
+}

--- a/samples/Radicle.Sample.CLI/Evaluators/WaitEvaluator.cs
+++ b/samples/Radicle.Sample.CLI/Evaluators/WaitEvaluator.cs
@@ -1,0 +1,108 @@
+﻿namespace Radicle.Sample.CLI.Evaluators;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Radicle.CLI.Evaluators;
+using Radicle.CLI.Models;
+using Radicle.Common;
+using Radicle.Common.Check;
+using Radicle.Common.Extensions;
+using Radicle.Common.Tokenization.Models;
+using Radicle.Sample.CLI.Evaluators.Base;
+
+/// <summary>
+/// "WAIT" command evaluator.
+/// </summary>
+internal sealed class WaitEvaluator : CommandEvaluator
+{
+    /// <summary>
+    /// Main verb of this command evaluator.
+    /// </summary>
+    public static readonly CommandVerb MainVerb = new("WAIT");
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WaitEvaluator"/> class.
+    /// </summary>
+    public WaitEvaluator()
+    {
+    }
+
+    /// <inheritdoc/>
+    public override ICommandGroup Group => SampleGroup.Instance;
+
+    /// <inheritdoc/>
+    public override CommandVerb Verb => MainVerb;
+
+    /// <inheritdoc/>
+    public override string ArgumentsDocTemplate =>
+            "seconds";
+
+    /// <inheritdoc/>
+    public override string Summary =>
+            "Blocks/waits specified amound of seconds";
+
+    /// <inheritdoc/>
+    public override string Since => "0.3.0";
+
+    /// <inheritdoc/>
+    public override string TimeComplexityDoc => "O(N) where N is wait time";
+
+    /// <inheritdoc/>
+    protected override Task<EvaluationOutput> EvaluateEmptyAsync(
+            SampleREPLEvaluator context,
+            TransparentProgress<long>? progress = null,
+            CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(EvaluationOutput.ErrorFrom(
+                $"Wrong number of arguments for '{this.Verb.DocName}' command."));
+    }
+
+    /// <inheritdoc/>
+    protected override async Task<EvaluationOutput> EvaluateArgsAsync(
+            SampleREPLEvaluator context,
+            TokenWithValue[] arguments,
+            TransparentProgress<long>? progress,
+            CancellationToken cancellationToken = default)
+    {
+        Ensure.Param(progress).Done();
+
+        if (arguments.Length != 1)
+        {
+            return EvaluationOutput.ErrorFrom($"Wrong number of arguments for '{this.Verb.DocName}' command.");
+        }
+        else if (TryParseInt64(arguments[0], out long seconds))
+        {
+            DateTime now = DateTime.UtcNow;
+            TimeSpan delay = seconds <= 0
+                    ? TimeSpan.Zero
+                    : TimeSpan.FromSeconds(seconds);
+            TimeSpan reportSpan = TimeSpan.FromSeconds(0.2);
+
+            if (progress is not null)
+            {
+                progress.Total = (long)Math.Round(delay / reportSpan);
+            }
+
+            long counter = 0;
+
+            while (!now.IsOlderThan(delay))
+            {
+                progress?.Report(++counter);
+
+                cancellationToken.ThrowIfCancellationRequested();
+
+                await Task.Delay(
+                        reportSpan,
+                        cancellationToken).ConfigureAwait(false);
+            }
+
+            return EvaluationOutput.NoOp;
+        }
+        else
+        {
+            return EvaluationOutput.ErrorFrom(
+                    $"Invalid option for '{this.Verb.DocName}'. Try HELP '{this.Verb.DocName}'.");
+        }
+    }
+}

--- a/samples/Radicle.Sample.CLI/Program.cs
+++ b/samples/Radicle.Sample.CLI/Program.cs
@@ -1,16 +1,18 @@
 namespace Radicle.Sample.CLI;
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
+using Radicle.CLI.REPL;
 using Radicle.Common.Check;
 
 /// <summary>
-/// Main entry point of Radicle CLI sample project.
+/// Main entry point of REPL CLI sample project.
 /// </summary>
 public static class Program
 {
     /// <summary>
-    /// Main entry point of app.
+    /// Main entry point.
     /// </summary>
     /// <param name="args">CLI arguments.</param>
     /// <returns>Awaitable task.</returns>
@@ -18,10 +20,69 @@ public static class Program
     {
         Ensure.Param(args).AllNotNull().Done();
 
-#pragma warning disable CA1303 // Do not pass literals as localized parameters
-        Console.WriteLine("OK");
-#pragma warning restore CA1303 // Do not pass literals as localized parameters
+        // Allow fast quiting
+        Console.TreatControlCAsInput = false;
 
-        await Task.Delay(1).ConfigureAwait(false);
+        using CancellationTokenSource source = new();
+
+        SampleREPLEvaluator evaluator = await SampleREPLEvaluator.CreateAsync()
+                .ConfigureAwait(false);
+
+        CancellationToken token = source.Token;
+
+        Console.CancelKeyPress += (sender, cancelArgs) =>
+        {
+            Console.WriteLine();
+            Console.WriteLine("SIGINT was received. Canceling now.");
+            source.Cancel();
+        };
+
+        WriteHi();
+        WriteVersionInfo();
+
+        REPLEventLoop loop = new(evaluator.ReaderWriter, evaluator);
+
+        try
+        {
+            await loop.RunAsync(token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            WriteGoodbye(true);
+
+            // http://www.tldp.org/LDP/abs/html/exitcodes.html
+            Environment.Exit(130);
+        }
+
+        WriteGoodbye();
+
+        Environment.Exit(0);
     }
+
+#pragma warning disable CA1303 // Do not pass literals as localized parameters
+    private static void WriteHi()
+    {
+        Console.WriteLine("Welcome to Radicle sample CLI, type command or 'help'|'?'");
+    }
+
+    private static void WriteGoodbye(bool forced = false)
+    {
+        if (forced)
+        {
+            Console.WriteLine();
+            Console.WriteLine("Forced exit, quitting");
+        }
+        else
+        {
+            Console.WriteLine();
+            Console.WriteLine("Good bye ...");
+        }
+    }
+
+    private static void WriteVersionInfo()
+    {
+        Console.WriteLine($"`- {ThisAssembly.Git.Tag} ({ThisAssembly.Git.CommitDate} {ThisAssembly.Git.Commit} [+{ThisAssembly.Git.Commits}])");
+    }
+
+#pragma warning restore CA1303 // Do not pass literals as localized parameters
 }

--- a/samples/Radicle.Sample.CLI/Radicle.Sample.CLI.csproj
+++ b/samples/Radicle.Sample.CLI/Radicle.Sample.CLI.csproj
@@ -23,15 +23,16 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.354">
+        <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Roslynator.Analyzers" Version="4.1.0">
+        <PackageReference Include="Roslynator.Analyzers" Version="4.1.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.SourceLink.Bitbucket.Git" Version="1.1.1" PrivateAssets="All" />
+        <PackageReference Include="GitInfo" Version="2.2.0" PrivateAssets="All" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/Radicle.Sample.CLI/SampleREPLEvaluator.cs
+++ b/samples/Radicle.Sample.CLI/SampleREPLEvaluator.cs
@@ -1,0 +1,201 @@
+﻿namespace Radicle.Sample.CLI;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Radicle.CLI.Evaluators;
+using Radicle.CLI.Evaluators.Generic;
+using Radicle.CLI.IO;
+using Radicle.CLI.Models;
+using Radicle.CLI.REPL;
+using Radicle.Common;
+using Radicle.Common.Check;
+using Radicle.Common.Tokenization;
+using Radicle.Common.Tokenization.Models;
+using Radicle.Sample.CLI.Evaluators;
+
+/// <summary>
+/// Implementation of <see cref="IREPLEvaluator"/>.
+/// </summary>
+public sealed class SampleREPLEvaluator : IREPLEvaluator, IEvaluationContext
+{
+    private readonly CLILikeArgumentsTokenizer argumentTokenizer = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SampleREPLEvaluator"/> class.
+    /// </summary>
+    /// <param name="stylingProvider">Styling provider.</param>
+    /// <param name="history">History.</param>
+    /// <param name="readerWriter">Reader and writer.</param>
+    /// <param name="bundle">Bundle of evaluators.</param>
+    private SampleREPLEvaluator(
+            IREPLStylingProvider stylingProvider,
+            IREPLInputHistory history,
+            IREPLReaderWriter readerWriter,
+            CommandEvaluatorBundle<EvaluationOutput, SampleREPLEvaluator> bundle)
+    {
+        this.StylingProvider = stylingProvider;
+        this.History = history;
+        this.ReaderWriter = readerWriter;
+        this.Bundle = bundle;
+    }
+
+    /// <inheritdoc/>
+    public IREPLStylingProvider StylingProvider { get; }
+
+    /// <inheritdoc/>
+    public IREPLInputHistory History { get; }
+
+    /// <summary>
+    /// Gets used reader/writer.
+    /// </summary>
+    public IREPLReaderWriter ReaderWriter { get; }
+
+    /// <summary>
+    /// Gets bundle with individual evaluators.
+    /// </summary>
+    public CommandEvaluatorBundle<EvaluationOutput, SampleREPLEvaluator> Bundle { get; }
+
+    /// <inheritdoc/>
+    public CommandEvaluatorBundle Commands => this.Bundle;
+
+    /// <summary>
+    /// Create instance of <see cref="SampleREPLEvaluator"/>.
+    /// </summary>
+    /// <returns>Instance of <see cref="SampleREPLEvaluator"/>.</returns>
+    public static async Task<SampleREPLEvaluator> CreateAsync()
+    {
+        CommandEvaluatorBundle<EvaluationOutput, SampleREPLEvaluator> bundle = new()
+        {
+            new EchoEvaluator(),
+            new HelpEvaluator(),
+            new HistoryEvaluator(),
+            new WaitEvaluator(),
+            new QuitEvaluator(),
+            new FooEvaluator(),
+        };
+        IREPLStylingProvider stylingProvider = new SampleREPLStylingProvider(bundle);
+        IREPLInputHistory history = await ConstructHistoryAsync().ConfigureAwait(false);
+        IREPLReaderWriter readerWriter = new REPLConsoleReaderWriter(
+                stylingProvider,
+                history);
+
+        return new SampleREPLEvaluator(
+                stylingProvider,
+                history,
+                readerWriter,
+                bundle);
+    }
+
+    /// <inheritdoc/>
+    public EvaluationOutputPromise Evaluate(
+            string input,
+            CancellationToken cancellationToken = default)
+    {
+        Ensure.Param(input).Done();
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            return EvaluationOutputPromise.Completed(EvaluationOutput.NoOp);
+        }
+
+        TokenWithValue[] arguments = this.argumentTokenizer.Parse(input).ToArray();
+
+        if (arguments.Length == 0)
+        {
+            return EvaluationOutputPromise.Completed(EvaluationOutput.NoOp);
+        }
+
+        TransparentProgress<long> progress = new();
+
+        return new EvaluationOutputPromise(
+                this.EvaluateInternal(
+                    arguments,
+                    progress: progress,
+                    cancellationToken: cancellationToken),
+                progress: progress);
+    }
+
+    /// <inheritdoc/>
+    public async Task AuditEvaluation(
+            string input,
+            TimeSpan elapsed,
+            CancellationToken cancellationToken = default)
+    {
+        if (this.History.Push(input))
+        {
+            string filePath = HistoryReader.GetFilePath(".radicle_sample_cli_history");
+            _ = await HistoryReader.TryAppendHistoryAsync(
+                    filePath,
+                    new[] { input }).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task<REPLInputHistory> ConstructHistoryAsync()
+    {
+        string filePath = HistoryReader.GetFilePath(".radicle_sample_cli_history");
+        ICollection<string> rawHistory = await HistoryReader
+                .TryReadHistoryAsync(filePath)
+                .ConfigureAwait(false);
+        REPLInputHistory history = new(
+                initialRecords: rawHistory,
+                ignoreRepeatedInputs: true);
+
+        // trim stored long history
+        if (rawHistory.Count > 2042)
+        {
+            _ = await HistoryReader.TryWriteHistoryAsync(
+                    filePath,
+                    rawHistory.Skip(1024)).ConfigureAwait(false);
+        }
+
+        return history;
+    }
+
+    private async Task<EvaluationOutput> EvaluateInternal(
+            TokenWithValue[] arguments,
+            TransparentProgress<long>? progress = null,
+            CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (this.Bundle.TryMapByVerbOrSynonym(
+                arguments,
+                out ICommandEvaluator<EvaluationOutput, SampleREPLEvaluator>? evaluator,
+                out TokenWithValue[]? remainingArguments))
+        {
+            try
+            {
+                return await evaluator
+                        .EvaluateAsync(
+                            remainingArguments,
+                            this,
+                            progress: progress,
+                            cancellationToken: cancellationToken)
+                        .ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception e)
+#pragma warning restore CA1031 // Do not catch general exception types
+            {
+                return EvaluationOutput.ErrorFrom("BUG:", e);
+            }
+        }
+        else
+        {
+            string argumentsPrintout = string.Join(
+                    ' ',
+                    arguments.Select(a => Dump.Literal(a)));
+
+            return EvaluationOutput.ErrorFrom($"Unknown verb: {argumentsPrintout}");
+        }
+    }
+}

--- a/samples/Radicle.Sample.CLI/SampleREPLStylingProvider.cs
+++ b/samples/Radicle.Sample.CLI/SampleREPLStylingProvider.cs
@@ -1,0 +1,85 @@
+﻿namespace Radicle.Sample.CLI;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Radicle.CLI.Evaluators;
+using Radicle.CLI.Models;
+using Radicle.CLI.REPL;
+using Radicle.Common.Check;
+
+/// <summary>
+/// Implementation of <see cref="IREPLStylingProvider"/>.
+/// </summary>
+internal class SampleREPLStylingProvider : IREPLStylingProvider
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SampleREPLStylingProvider"/> class.
+    /// </summary>
+    /// <param name="bundle">Current bundle used.</param>
+    public SampleREPLStylingProvider(CommandEvaluatorBundle bundle)
+    {
+        this.Bundle = Ensure.Param(bundle).Value;
+    }
+
+    /// <inheritdoc />
+    public string PromptStringOne => "sample> ";
+
+    /// <inheritdoc />
+    public bool EnableColor => true;
+
+    /// <inheritdoc />
+    public SpinnerType SpinnerType => SpinnerType.Snake;
+
+    /// <inheritdoc />
+    public ProgressBarsType ProgressBarsType => ProgressBarsType.BlockDots;
+
+    /// <summary>
+    /// Gets currently used bundle.
+    /// </summary>
+    public CommandEvaluatorBundle Bundle { get; }
+
+    /// <inheritdoc />
+    public string GetSuggestionTail(string input)
+    {
+        Ensure.Param(input).Done();
+
+        // TODO: recursive + extract
+        string[] all = this.Bundle
+                .GetAllListed()
+                .Select(r => r.Evaluator.Verb.Value)
+                .ToArray();
+
+        foreach (string v in all)
+        {
+            if (v.StartsWith(input, StringComparison.OrdinalIgnoreCase))
+            {
+                return v[input.Length..];
+            }
+        }
+
+        return string.Empty;
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<string> GetAutocomplete(string input)
+    {
+        Ensure.Param(input).Done();
+
+        string[] all = this.Bundle
+                .GetAllListed()
+                .Select(r => r.Evaluator.Verb.Value)
+                .ToArray();
+        List<string> autocomplete = new();
+
+        foreach (string v in all)
+        {
+            if (v.StartsWith(input, StringComparison.OrdinalIgnoreCase))
+            {
+                autocomplete.Add(v);
+            }
+        }
+
+        return autocomplete;
+    }
+}

--- a/src/Radicle.CLI/src/Evaluators/Base/CommandEvaluator.cs
+++ b/src/Radicle.CLI/src/Evaluators/Base/CommandEvaluator.cs
@@ -1,0 +1,206 @@
+﻿namespace Radicle.CLI.Evaluators.Base;
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Radicle.CLI.Evaluators.Generic;
+using Radicle.Common;
+using Radicle.Common.Check;
+using Radicle.Common.Tokenization.Models;
+
+/// <summary>
+/// Base class for <see cref="ICommandEvaluator"/>
+/// implementation.
+/// </summary>
+/// <typeparam name="TOut">Type of the execution raw output.</typeparam>
+/// <typeparam name="TContext">Type of the evaluation context.</typeparam>
+public abstract class CommandEvaluator<TOut, TContext> : ICommandEvaluator<TOut, TContext>
+    where TOut : notnull
+    where TContext : IEvaluationContext
+{
+    /// <summary>
+    /// Allowed styles for parsing integer arguments.
+    /// </summary>
+    private const NumberStyles IntegerNumberStyles = NumberStyles.AllowLeadingSign;
+
+    private static readonly Regex IntegerNumberStyleRegex =
+            new("\\A(-)?[0-9]+\\z", RegexOptions.Compiled);
+
+    private ImmutableArray<ICommandEvaluator>? untypedSubs;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CommandEvaluator{TOut, TContext}"/> class.
+    /// </summary>
+    protected CommandEvaluator()
+    {
+    }
+
+    /// <inheritdoc/>
+    public abstract ICommandGroup Group { get; }
+
+    /// <inheritdoc/>
+    public abstract CommandVerb Verb { get; }
+
+    /// <inheritdoc/>
+    public ImmutableHashSet<CommandVerbSynonym> VerbSynonyms { get; protected init; } =
+            ImmutableHashSet<CommandVerbSynonym>.Empty;
+
+    /// <inheritdoc/>
+    public virtual bool DisableListing { get; }
+
+    /// <inheritdoc/>
+    public virtual bool IsLegacy { get; }
+
+    /// <inheritdoc/>
+    public virtual bool IsExperimental { get; }
+
+    /// <inheritdoc/>
+    public abstract string ArgumentsDocTemplate { get; }
+
+    /// <inheritdoc/>
+    public abstract string TimeComplexityDoc { get; }
+
+    /// <inheritdoc/>
+    public abstract string Summary { get; }
+
+    /// <inheritdoc/>
+    public ImmutableArray<SimpleMarkdownText> Doc { get; protected init; } =
+            ImmutableArray<SimpleMarkdownText>.Empty;
+
+    /// <inheritdoc/>
+    public abstract string Since { get; }
+
+    /// <inheritdoc/>
+    public ImmutableSortedDictionary<string, SimpleMarkdownText> ChangeLog { get; protected init; } =
+            ImmutableSortedDictionary<string, SimpleMarkdownText>.Empty;
+
+    /// <inheritdoc/>
+    public ImmutableArray<ICommandEvaluator<TOut, TContext>> Subs { get; protected init; } =
+            ImmutableArray<ICommandEvaluator<TOut, TContext>>.Empty;
+
+    /// <inheritdoc/>
+    ImmutableArray<ICommandEvaluator> ICommandEvaluator.Subs =>
+            this.untypedSubs ??= this.Subs.Cast<ICommandEvaluator>().ToImmutableArray();
+
+    /// <inheritdoc/>
+    public async Task<TOut> EvaluateAsync(
+            TokenWithValue[] arguments,
+            TContext context,
+            TransparentProgress<long>? progress = null,
+            CancellationToken cancellationToken = default)
+    {
+        Ensure.Param(arguments).AllNotNull().Done();
+        Ensure.Param(context).Done();
+
+        if (arguments.Length == 0)
+        {
+            return await this.EvaluateEmptyAsync(
+                    context,
+                    progress: progress,
+                    cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+
+        return await this.EvaluateArgsAsync(
+                context,
+                arguments,
+                progress: progress,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public IEnumerable<CommandVerb[]> GetAllApplicableVerbs()
+    {
+        CommandVerb[] head = new[] { this.Verb };
+
+        yield return head;
+
+        foreach (ICommandEvaluator<TOut, TContext> sub in this.Subs)
+        {
+            foreach (CommandVerb[] verbs in sub.GetAllApplicableVerbs())
+            {
+                yield return head.Concat(verbs).ToArray();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Try parse given <paramref name="argument"/>
+    /// to int64 value according to common interpreter rules.
+    /// </summary>
+    /// <param name="argument">Argument to parse.</param>
+    /// <param name="value">Parsed value.</param>
+    /// <returns><see langword="true"/> if parsed successfully,
+    ///     <see langword="false"/> otherwise.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if required value
+    ///     is <see langword="null"/>.</exception>
+    protected static bool TryParseInt64(
+            TokenWithValue argument,
+            out long value)
+    {
+        value = default;
+
+        if (argument is TokenString ts
+                && IntegerNumberStyleRegex.IsMatch(ts.StringValue)
+                && long.TryParse(
+                    ts.StringValue,
+                    IntegerNumberStyles,
+                    CultureInfo.InvariantCulture,
+                    out long d))
+        {
+            value = d;
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Returns "yes" or "no" string according to <paramref name="value"/>.
+    /// This makes better UX than boolean values.
+    /// </summary>
+    /// <param name="value">Value to determine output on.</param>
+    /// <returns>"yes" or "no" string.</returns>
+    protected static string GetYesNo(bool value)
+    {
+        return value ? "yes" : "no";
+    }
+
+    /// <summary>
+    /// Evaluator argument less input.
+    /// </summary>
+    /// <param name="context">Context to work in.</param>
+    /// <param name="progress">Optional progress.</param>
+    /// <param name="cancellationToken">Optional cancellation token.</param>
+    /// <returns>Instance of <typeparamref name="TOut"/>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    /// <exception cref="OperationCanceledException">Thrown
+    ///     if <paramref name="cancellationToken"/> was cancelled.</exception>
+    protected abstract Task<TOut> EvaluateEmptyAsync(
+            TContext context,
+            TransparentProgress<long>? progress = null,
+            CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Evaluator input with arguments.
+    /// </summary>
+    /// <param name="context">Context to work in.</param>
+    /// <param name="arguments">Non empty collection of arguments.</param>
+    /// <param name="progress">Optional progress.</param>
+    /// <param name="cancellationToken">Optional cancellation token.</param>
+    /// <returns>Instance of <typeparamref name="TOut"/>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    /// <exception cref="OperationCanceledException">Thrown
+    ///     if <paramref name="cancellationToken"/> was cancelled.</exception>
+    protected abstract Task<TOut> EvaluateArgsAsync(
+            TContext context,
+            TokenWithValue[] arguments,
+            TransparentProgress<long>? progress = null,
+            CancellationToken cancellationToken = default);
+}

--- a/src/Radicle.CLI/src/Evaluators/CommandEvaluatorBundle.cs
+++ b/src/Radicle.CLI/src/Evaluators/CommandEvaluatorBundle.cs
@@ -1,0 +1,442 @@
+namespace Radicle.CLI.Evaluators;
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Radicle.Common.Check;
+using Radicle.Common.Tokenization.Models;
+
+/// <summary>
+/// Bundle of command evaluators of specific type.
+/// </summary>
+public abstract class CommandEvaluatorBundle : IEnumerable<CommandEvaluatorRecord>
+{
+    private readonly Dictionary<CommandVerb, CommandEvaluatorRecord> byVerb = new();
+
+    private readonly Dictionary<CommandVerbSynonym, CommandVerb> bySynonym = new();
+
+    private readonly Dictionary<CommandGroupName, ImmutableArray<CommandEvaluatorRecord>> byGroupAndListed = new();
+
+    private readonly HashSet<CommandEvaluatorRecord> allListed = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CommandEvaluatorBundle"/> class.
+    /// </summary>
+    internal CommandEvaluatorBundle()
+    {
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether this collection is empty.
+    /// </summary>
+    public bool IsEmpty => this.byVerb.Count == 0;
+
+    /// <inheritdoc/>
+    public IEnumerator<CommandEvaluatorRecord> GetEnumerator()
+    {
+        return this.byVerb.Values.GetEnumerator();
+    }
+
+    /// <inheritdoc/>
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return this.GetEnumerator();
+    }
+
+    /// <summary>
+    /// Gets all instances of <see cref="CommandEvaluatorRecord"/>
+    /// with matching <paramref name="name"/>.
+    /// </summary>
+    /// <param name="name">Group name.</param>
+    /// <param name="recursive">Flag determining if to perform recursive listing.</param>
+    /// <returns>Collection of first level command evaluator
+    ///     with matching <paramref name="name"/>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    public IEnumerable<CommandEvaluatorRecord> GetByGroup(
+            CommandGroupName name,
+            bool recursive = false)
+    {
+        Ensure.Param(name).Done();
+
+        if (this.byGroupAndListed.TryGetValue(name, out ImmutableArray<CommandEvaluatorRecord> list))
+        {
+            foreach (CommandEvaluatorRecord item in list)
+            {
+                yield return item;
+
+                if (recursive)
+                {
+                    foreach (CommandEvaluatorRecord sub in
+                        item.SubCollection.GetByGroup(name, recursive: true))
+                    {
+                        yield return sub;
+                    }
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Tries to complete verb with first level instances verbs of contained
+    /// <see cref="CommandEvaluatorRecord"/> with verb or as a fallback synonym.
+    /// </summary>
+    /// <param name="value">Value to complete case insensitivelly
+    ///     to the full verb or synonym, note verbs have higher precedence.</param>
+    /// <param name="completion">Returned completion of the
+    ///     <paramref name="value"/> if any. E.g. "FOO" for "F",
+    ///     or "foo" for "f".</param>
+    /// <returns><see langword="true"/> if verb or synonym was found,
+    ///     <see langword="false"/> otherwise.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    public bool TryCompleteVerbOrSynonym(
+            string value,
+            [NotNullWhen(returnValue: true)] out string? completion)
+    {
+        Ensure.Param(value).Done();
+
+        completion = default;
+
+        if (CommandVerb.Specification.IsValid(value))
+        {
+            CommandVerb? foundVerb = default;
+
+            foreach (CommandVerb verb in this.byVerb.Keys.Where(v =>
+                        v.Value.StartsWith(value, StringComparison.OrdinalIgnoreCase)))
+            {
+                if (foundVerb is null)
+                {
+                    foundVerb = verb;
+                }
+                else
+                {
+                    foundVerb = default;
+                    break;
+                }
+            }
+
+            if (foundVerb?.Value.Length > value.Length)
+            {
+                completion = char.IsLower(value[0])
+                        ? foundVerb.InvariantValue[value.Length..]
+                        : foundVerb.Value[value.Length..];
+
+                return true;
+            }
+        }
+
+        if (CommandVerbSynonym.Specification.IsValid(value))
+        {
+            CommandVerbSynonym? foundVerbSynonym = default;
+
+            foreach (CommandVerbSynonym verbSynonym in this.bySynonym.Keys.Where(v =>
+                        v.Value.StartsWith(value, StringComparison.OrdinalIgnoreCase)))
+            {
+                if (foundVerbSynonym is null)
+                {
+                    foundVerbSynonym = verbSynonym;
+                }
+                else
+                {
+                    foundVerbSynonym = default;
+                    break;
+                }
+            }
+
+            if (foundVerbSynonym?.Value.Length > value.Length)
+            {
+                completion = char.IsLower(value[0])
+                        ? foundVerbSynonym.InvariantValue[value.Length..]
+                        : foundVerbSynonym.Value[value.Length..];
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Gets all instances of <see cref="CommandEvaluatorRecord"/>
+    /// with matching verbs or as fallback synonyms.
+    /// Unlike the <see cref="TryGetByVerbOrSynonym(string, out CommandEvaluatorRecord?)"/>
+    /// this method traverses collection recursively.
+    /// </summary>
+    /// <param name="values">Values to compare case insensitivelly
+    ///     to verbs or synonyms, note verbs have higher precedence
+    ///     and all values of <paramref name="values"/> need to
+    ///     match existing evaluator.</param>
+    /// <param name="completion">Returned evaluator if any.</param>
+    /// <returns><see langword="true"/> if evaluator was found,
+    ///     <see langword="false"/> otherwise.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    public bool TryCompleteVerbOrSynonym(
+            string[] values,
+            [NotNullWhen(returnValue: true)] out string? completion)
+    {
+        Ensure.Param(values).AllNotNull().Done();
+
+        completion = default;
+
+        if (values.Length == 1
+                && this.TryCompleteVerbOrSynonym(values[0], out completion))
+        {
+            return true;
+        }
+        else if (values.Length > 1
+                && this.TryGetByVerbOrSynonym(values[0], out CommandEvaluatorRecord? recorn))
+        {
+            return recorn.SubCollection.TryCompleteVerbOrSynonym(
+                        values.Skip(1).ToArray(),
+                        out completion);
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Gets all first level instances of <see cref="CommandEvaluatorRecord"/>
+    /// which can be listed, for all evaluators enumerate this instance.
+    /// </summary>
+    /// <param name="recursive">Flag determining recursive listing.</param>
+    /// <returns>Collection of listable first level
+    ///     command evaluators.</returns>
+    public IEnumerable<CommandEvaluatorRecord> GetAllListed(
+            bool recursive = false)
+    {
+        foreach (CommandEvaluatorRecord item in this.allListed)
+        {
+            yield return item;
+
+            if (recursive)
+            {
+                foreach (CommandEvaluatorRecord sub in
+                        item.SubCollection.GetAllListed(recursive: true))
+                {
+                    yield return sub;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets all first level instances of <see cref="CommandEvaluatorRecord"/>
+    /// with matching given verb or as fallback synonym.
+    /// </summary>
+    /// <param name="value">Value to compare case insensitivelly
+    ///     to verb or synonym, note verbs have higher precedence.</param>
+    /// <param name="record">Returned evaluator record if any.</param>
+    /// <returns><see langword="true"/> if evaluator was found,
+    ///     <see langword="false"/> otherwise.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    public bool TryGetByVerbOrSynonym(
+            string value,
+            [NotNullWhen(returnValue: true)] out CommandEvaluatorRecord? record)
+    {
+        Ensure.Param(value).Done();
+
+        record = default;
+
+        if (CommandVerb.Specification.IsValid(value)
+                && this.byVerb.TryGetValue(new CommandVerb(value), out record))
+        {
+            return true;
+        }
+
+        if (CommandVerbSynonym.Specification.IsValid(value)
+                && this.bySynonym.TryGetValue(new CommandVerbSynonym(value), out CommandVerb? verb)
+                && this.byVerb.TryGetValue(verb, out record))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Gets all instance of <see cref="CommandEvaluatorRecord"/>
+    /// with matching verbs or as fallback synonyms. Unlike
+    /// <see cref="TryGetByVerbOrSynonym(string, out CommandEvaluatorRecord?)"/>
+    /// this method traverses collection rreecursively.
+    /// </summary>
+    /// <param name="values">Values to compare case insensitivelly
+    ///     to verbs or synonyms, note verbs have higher precedence
+    ///     and all values of <paramref name="values"/> need to
+    ///     match existing evaluator.</param>
+    /// <param name="record">Returned evaluator if any.</param>
+    /// <returns><see langword="true"/> if evaluator was found,
+    ///     <see langword="false"/> otherwise.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    public bool TryGetByVerbOrSynonym(
+            string[] values,
+            [NotNullWhen(returnValue: true)] out CommandEvaluatorRecord? record)
+    {
+        Ensure.Param(values).AllNotNull().Done();
+
+        record = default;
+
+        if (values.Length > 0
+                && this.TryGetByVerbOrSynonym(values[0], out record))
+        {
+            if (values.Length > 1)
+            {
+                return record.SubCollection.TryGetByVerbOrSynonym(
+                        values.Skip(1).ToArray(),
+                        out record);
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Gets all instance of <see cref="CommandEvaluatorRecord"/>
+    /// with matching verbs or synonyms (as fallback). Unlike
+    /// <see cref="TryGetByVerbOrSynonym(string, out CommandEvaluatorRecord?)"/>
+    /// this method traverses collection recursively.
+    /// </summary>
+    /// <param name="arguments">Values to compare case insensitivelly
+    ///     to verbs or synonyms, note verbs have higher precedence.</param>
+    /// <param name="record">Returned evaluator if any.</param>
+    /// <param name="remainingArguments">Returned remaining arguments
+    ///     from <paramref name="arguments"/> which were left after
+    ///     mapping verbs to evaluator.</param>
+    /// <returns><see langword="true"/> if evaluator was found,
+    ///     <see langword="false"/> otherwise.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    protected bool TryMapByVerbOrSynonym(
+            TokenWithValue[] arguments,
+            [NotNullWhen(returnValue: true)] out CommandEvaluatorRecord? record,
+            [NotNullWhen(returnValue: true)] out TokenWithValue[]? remainingArguments)
+    {
+        Ensure.Param(arguments).AllNotNull().Done();
+
+        record = default;
+        remainingArguments = default;
+
+        if (arguments.Length > 0
+                && arguments[0] is TokenString ts
+                && this.TryGetByVerbOrSynonym(ts.StringValue, out record))
+        {
+            if (arguments.Length > 1)
+            {
+                TokenWithValue[] tail = arguments.Skip(1).ToArray();
+
+                if (record.SubCollection.TryMapByVerbOrSynonym(
+                        tail,
+                        out CommandEvaluatorRecord? subRecord,
+                        out TokenWithValue[]? subRemainingArguments))
+                {
+                    record = subRecord;
+                    remainingArguments = subRemainingArguments;
+                }
+                else
+                {
+                    remainingArguments = tail;
+                }
+
+                return true;
+            }
+
+            remainingArguments = Array.Empty<TokenWithValue>();
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Add new instance of <see cref="ICommandEvaluator"/>
+    /// to the bundle collection.
+    /// </summary>
+    /// <param name="evaluator">Evaluator instance to add.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown if given
+    ///     <paramref name="evaluator"/> was already added.</exception>
+    protected void Add(ICommandEvaluator evaluator)
+    {
+        this.AddInternal(ImmutableList<CommandEvaluatorRecord>.Empty, evaluator);
+    }
+
+    /// <summary>
+    /// Create new instance of the derived class.
+    /// </summary>
+    /// <returns>Instance of <see cref="CommandEvaluatorBundle"/>.</returns>
+    protected abstract CommandEvaluatorBundle CreateNewInstance();
+
+    /// <summary>
+    /// Add new instance of <see cref="ICommandEvaluator"/>
+    /// to collection.
+    /// </summary>
+    /// <param name="ancestors">Ancestors.</param>
+    /// <param name="evaluator">Evaluator instance to add.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown if given
+    ///     <paramref name="evaluator"/> was already added.</exception>
+    private void AddInternal(
+            ImmutableList<CommandEvaluatorRecord> ancestors,
+            ICommandEvaluator evaluator)
+    {
+        Ensure.Param(evaluator).Done();
+
+        if (this.byVerb.ContainsKey(evaluator.Verb))
+        {
+            throw new ArgumentException(
+                    $"Duplicate evaluator verb '{evaluator.Verb.DocName}' added: {evaluator.GetType()}",
+                    nameof(evaluator));
+        }
+
+        if (evaluator.VerbSynonyms.Any(s => this.bySynonym.ContainsKey(s)))
+        {
+            string synonyms = string.Join(
+                    ", ",
+                    evaluator.VerbSynonyms.Select(s => $"'{s.DocName}'"));
+
+            throw new ArgumentException(
+                    $"Duplicate evaluator verb synonym {synonyms} added: {evaluator.GetType()}",
+                    nameof(evaluator));
+        }
+
+        CommandEvaluatorBundle subCollection = this.CreateNewInstance();
+        CommandEvaluatorRecord record = new(ancestors, evaluator, subCollection);
+
+        foreach (ICommandEvaluator sub in evaluator.Subs)
+        {
+            ImmutableList<CommandEvaluatorRecord> subAncestors = ancestors.Add(record);
+            subCollection.AddInternal(subAncestors, sub);
+        }
+
+        if (!evaluator.DisableListing)
+        {
+            CommandGroupName groupName = evaluator.Group.Name;
+
+            if (!this.byGroupAndListed.ContainsKey(groupName))
+            {
+                this.byGroupAndListed[groupName] = ImmutableArray<CommandEvaluatorRecord>.Empty;
+            }
+
+            this.byGroupAndListed[groupName] = this.byGroupAndListed[groupName].Add(record);
+            _ = this.allListed.Add(record);
+        }
+
+        this.byVerb[evaluator.Verb] = record;
+
+        foreach (CommandVerbSynonym synonym in evaluator.VerbSynonyms)
+        {
+            this.bySynonym[synonym] = evaluator.Verb;
+        }
+    }
+}

--- a/src/Radicle.CLI/src/Evaluators/CommandEvaluatorRecord.cs
+++ b/src/Radicle.CLI/src/Evaluators/CommandEvaluatorRecord.cs
@@ -1,0 +1,50 @@
+﻿namespace Radicle.CLI.Evaluators;
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Radicle.Common.Check;
+
+/// <summary>
+/// Immutable record of signle <see cref="ICommandEvaluator"/>.
+/// </summary>
+public sealed class CommandEvaluatorRecord
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CommandEvaluatorRecord"/> class.
+    /// </summary>
+    /// <param name="ancestors">Ancestors to this <paramref name="evaluator"/>.</param>
+    /// <param name="evaluator">Evaluator.</param>
+    /// <param name="subCollection">Subcollection for given
+    ///     <paramref name="evaluator"/>.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if reequired parameter is <see langword="null"/>.</exception>
+    public CommandEvaluatorRecord(
+            IEnumerable<CommandEvaluatorRecord> ancestors,
+            ICommandEvaluator evaluator,
+            CommandEvaluatorBundle subCollection)
+    {
+        this.Evaluator = Ensure.Param(evaluator).Value;
+        this.Ancestors = Ensure.Param(ancestors)
+                .AllNotNull()
+                .ToImmutableArray();
+        this.SubCollection = Ensure.Param(subCollection).Value;
+    }
+
+    /// <summary>
+    /// Gets instance of the evaluator.
+    /// </summary>
+    public ICommandEvaluator Evaluator { get; }
+
+    /// <summary>
+    /// Gets collection of parents to this <see cref="Evaluator"/>
+    /// in order from root to parent.
+    /// </summary>
+    public ImmutableArray<CommandEvaluatorRecord> Ancestors { get; }
+
+    /// <summary>
+    /// Gets sub collection for this <see cref="Evaluator"/>.
+    /// See <see cref="ICommandEvaluator.Subs"/>.
+    /// </summary>
+    public CommandEvaluatorBundle SubCollection { get; }
+}

--- a/src/Radicle.CLI/src/Evaluators/CommandGroupName.cs
+++ b/src/Radicle.CLI/src/Evaluators/CommandGroupName.cs
@@ -1,0 +1,42 @@
+﻿namespace Radicle.CLI.Evaluators;
+
+using System;
+using Radicle.Common.Check;
+using Radicle.Common.Check.Base;
+
+/// <summary>
+/// Immutable command group name.
+/// </summary>
+public sealed class CommandGroupName : TypedName<CommandGroupName>
+{
+    /// <summary>
+    /// Specification.
+    /// </summary>
+    public static readonly TypedNameSpec Specification = TypedNameSpec.Programming
+            .With(maxLength: 32, ignoreCaseWhenCompared: true);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CommandGroupName"/> class.
+    /// </summary>
+    /// <param name="name">Case insensitive programming name of the
+    ///     command group, with maximum length of 32 characters.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if the
+    ///     input exceeds allowed ranges.</exception>
+    /// <exception cref="ArgumentException">Thrown if the input does not
+    ///     conform to expected form.</exception>
+    public CommandGroupName(string name)
+        : base(name)
+    {
+    }
+
+    /// <inheritdoc />
+    public override TypedNameSpec Spec => Specification;
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return $"command group {base.ToString()}";
+    }
+}

--- a/src/Radicle.CLI/src/Evaluators/CommandVerb.cs
+++ b/src/Radicle.CLI/src/Evaluators/CommandVerb.cs
@@ -1,0 +1,52 @@
+﻿namespace Radicle.CLI.Evaluators;
+
+using System;
+using Radicle.Common.Check;
+using Radicle.Common.Check.Base;
+
+/// <summary>
+/// Immutable representation of the command verb.
+/// </summary>
+public sealed class CommandVerb : TypedName<CommandVerb>
+{
+    /// <summary>
+    /// Specification.
+    /// </summary>
+    public static readonly TypedNameSpec Specification = new(
+            "Command evaluator verb",
+            @"\A[a-z]+\z",
+            ignoreCaseInPattern: true,
+            ignoreCaseWhenCompared: true,
+            description: "alpha characters",
+            maxLength: 32);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CommandVerb"/> class.
+    /// </summary>
+    /// <param name="name">Case insensitive command verb,
+    ///     with maximum length of 42 characters.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if the
+    ///     input exceeds allowed ranges.</exception>
+    /// <exception cref="ArgumentException">Thrown if the input does not
+    ///     conform to expected form.</exception>
+    public CommandVerb(string name)
+        : base(name)
+    {
+    }
+
+    /// <inheritdoc />
+    public override TypedNameSpec Spec => Specification;
+
+    /// <summary>
+    /// Gets documentation name version which is capitalized.
+    /// </summary>
+    public string DocName => this.Value.ToUpperInvariant();
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return $"command evaluator verb {base.ToString()}";
+    }
+}

--- a/src/Radicle.CLI/src/Evaluators/CommandVerbSynonym.cs
+++ b/src/Radicle.CLI/src/Evaluators/CommandVerbSynonym.cs
@@ -1,0 +1,55 @@
+﻿namespace Radicle.CLI.Evaluators;
+
+using System;
+using Radicle.Common.Check;
+using Radicle.Common.Check.Base;
+
+/// <summary>
+/// Immutable representation of the command evaluator verb synonym.
+/// </summary>
+/// <remarks>Synonyms are to help people
+/// if they do not remember the specific verb
+/// which is instrumental for UX.</remarks>
+public sealed class CommandVerbSynonym : TypedName<CommandVerbSynonym>
+{
+    /// <summary>
+    /// Specification.
+    /// </summary>
+    public static readonly TypedNameSpec Specification = new(
+            "Command evaluator verb",
+            @"\A[a-z\?]+\z",
+            ignoreCaseInPattern: true,
+            ignoreCaseWhenCompared: true,
+            description: "alpha plus '?'",
+            maxLength: 32);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CommandVerbSynonym"/> class.
+    /// </summary>
+    /// <param name="name">Case insensitive command verb synonym,
+    ///     with maximum length of 32 characters.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if the
+    ///     input exceeds allowed ranges.</exception>
+    /// <exception cref="ArgumentException">Thrown if the input does not
+    ///     conform to expected form.</exception>
+    public CommandVerbSynonym(string name)
+        : base(name)
+    {
+    }
+
+    /// <inheritdoc />
+    public override TypedNameSpec Spec => Specification;
+
+    /// <summary>
+    /// Gets documentation name version which is capitalized.
+    /// </summary>
+    public string DocName => this.Value.ToUpperInvariant();
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return $"command evaluator verb synonym {base.ToString()}";
+    }
+}

--- a/src/Radicle.CLI/src/Evaluators/Generic/CommandEvaluatorBundle.cs
+++ b/src/Radicle.CLI/src/Evaluators/Generic/CommandEvaluatorBundle.cs
@@ -1,0 +1,67 @@
+﻿namespace Radicle.CLI.Evaluators.Generic;
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Radicle.Common.Tokenization.Models;
+
+/// <summary>
+/// Bundle of command evaluators of specific type.
+/// </summary>
+/// <typeparam name="TOut">Type of the execution raw output.</typeparam>
+/// <typeparam name="TContext">Type of the evaluation context.</typeparam>
+public sealed class CommandEvaluatorBundle<TOut, TContext> : CommandEvaluatorBundle
+    where TOut : notnull
+    where TContext : IEvaluationContext
+{
+    /// <summary>
+    /// Add new instance of <see cref="ICommandEvaluator"/>
+    /// to collection.
+    /// </summary>
+    /// <param name="evaluator">Evaluator instance to add.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown if given
+    ///     <paramref name="evaluator"/> was already added.</exception>
+    public void Add(ICommandEvaluator<TOut, TContext> evaluator)
+    {
+        base.Add(evaluator);
+    }
+
+    /// <summary>
+    /// Gets all instance of <see cref="ICommandEvaluator{TOut, TContext}"/>
+    /// with matching verbs or synonyms (as fallback). This method
+    /// traverses collection recursively.
+    /// </summary>
+    /// <param name="arguments">Values to compare case insensitivelly
+    ///     to verbs or synonyms, note verbs have higher precedence.</param>
+    /// <param name="evaluator">Returned evaluator if any.</param>
+    /// <param name="remainingArguments">Returned remaining arguments
+    ///     from <paramref name="arguments"/> which were left after
+    ///     mapping verbs to evaluator.</param>
+    /// <returns><see langword="true"/> if evaluator was found,
+    ///     <see langword="false"/> otherwise.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    public bool TryMapByVerbOrSynonym(
+            TokenWithValue[] arguments,
+            [NotNullWhen(returnValue: true)] out ICommandEvaluator<TOut, TContext>? evaluator,
+            [NotNullWhen(returnValue: true)] out TokenWithValue[]? remainingArguments)
+    {
+        evaluator = default;
+
+        if (this.TryMapByVerbOrSynonym(arguments, out CommandEvaluatorRecord? record, out remainingArguments))
+        {
+            evaluator = (ICommandEvaluator<TOut, TContext>)record.Evaluator;
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <inheritdoc/>
+    protected override CommandEvaluatorBundle CreateNewInstance()
+    {
+        return new CommandEvaluatorBundle<TOut, TContext>();
+    }
+}

--- a/src/Radicle.CLI/src/Evaluators/Generic/ICommandEvaluator.cs
+++ b/src/Radicle.CLI/src/Evaluators/Generic/ICommandEvaluator.cs
@@ -1,0 +1,48 @@
+﻿namespace Radicle.CLI.Evaluators.Generic;
+
+using System;
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Radicle.CLI.Models;
+using Radicle.Common;
+using Radicle.Common.Tokenization.Models;
+
+/// <summary>
+/// Interface of single command evaluator.
+/// </summary>
+/// <typeparam name="TOut">Type of the execution raw output.</typeparam>
+/// <typeparam name="TContext">Type of the evaluation context.</typeparam>
+public interface ICommandEvaluator<TOut, TContext> : ICommandEvaluator
+    where TOut : notnull
+    where TContext : IEvaluationContext
+{
+    /// <summary>
+    /// Gets collection of subcommands. When called by user they
+    /// are preceded by this <see cref="ICommandEvaluator.Verb"/> (e.g. subcommand
+    /// with main verb 'SUB' of the command with the main verb 'BASE'
+    /// is visible to user as 'BASE SUB ...').
+    /// </summary>
+    new ImmutableArray<ICommandEvaluator<TOut, TContext>> Subs { get; }
+
+    /// <summary>
+    /// Evaluate given <paramref name="arguments"/>.
+    /// <paramref name="arguments"/> do NOT contain
+    /// leading command evaluator verb.
+    /// </summary>
+    /// <param name="arguments">Collection of arguments,
+    ///     some of them can be empty.</param>
+    /// <param name="context">Context to work in.</param>
+    /// <param name="progress">Optional progress.</param>
+    /// <param name="cancellationToken">Optional cancellation token.</param>
+    /// <returns>Instance of <see cref="EvaluationOutput"/>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    /// <exception cref="OperationCanceledException">Thrown
+    ///     if <paramref name="cancellationToken"/> was cancelled.</exception>
+    Task<TOut> EvaluateAsync(
+            TokenWithValue[] arguments,
+            TContext context,
+            TransparentProgress<long>? progress = null,
+            CancellationToken cancellationToken = default);
+}

--- a/src/Radicle.CLI/src/Evaluators/ICommandEvaluator.cs
+++ b/src/Radicle.CLI/src/Evaluators/ICommandEvaluator.cs
@@ -1,0 +1,114 @@
+namespace Radicle.CLI.Evaluators;
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Radicle.Common.Tokenization.Models;
+
+/// <summary>
+/// Baee interface of single command evaluator.
+/// </summary>
+public interface ICommandEvaluator
+{
+    /// <summary>
+    /// Gets group this command evaluator belongs to.
+    /// </summary>
+    ICommandGroup Group { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether this evaluator
+    /// is legacy and will be removed in future.
+    /// </summary>
+    bool IsLegacy { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether this evaluator
+    /// is experimental and can be changed without notice.
+    /// </summary>
+    bool IsExperimental { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether to disable listing
+    /// of this command in the help when listing all commands
+    /// or commands by group. Defaults to <see langword="fase"/>.
+    /// </summary>
+    bool DisableListing { get; }
+
+    /// <summary>
+    /// Gets main verb which this instance can match.
+    /// </summary>
+    /// <remarks>Verbs as reserved words are allways in capital case
+    ///     see <see cref="CommandVerb.DocName"/>.</remarks>
+    CommandVerb Verb { get; }
+
+    /// <summary>
+    /// Gets alternative verbs which this instance can match.
+    /// Synonyms have always lower precedence than verbs.
+    /// </summary>
+    /// <remarks>Verbs as reserved words are allways in capital case
+    ///     see <see cref="CommandVerbSynonym.DocName"/>.</remarks>
+    ImmutableHashSet<CommandVerbSynonym> VerbSynonyms { get; }
+
+    /// <summary>
+    /// Gets documentation template for arguments following
+    /// <see cref="Verb"/>.
+    /// </summary>
+    /// <remarks>Optional groups are placed in square brackets "[" and "]",
+    /// groups can be nested, alternative options are denoted by pipe "|",
+    /// reserved words are allways in capital case,
+    /// user defined argument placeholders are in lower case as single words
+    /// or kebab-case, variable count arguments are denoted by "...",
+    /// empty template should be marked with "-". See https://redis.io/commands/ .</remarks>
+    string ArgumentsDocTemplate { get; }
+
+    /// <summary>
+    /// Gets human readable one line explanation of
+    /// this command evaluator time complexity. Use expressions like:
+    /// "O(N) where N stands for ..." or "O(1)" etc.
+    /// Do NOT use trailing period ".".
+    /// </summary>
+    string TimeComplexityDoc { get; }
+
+    /// <summary>
+    /// Gets human readable one line summary this command evaluator
+    /// with NO trailing period ".".
+    /// </summary>
+    string Summary { get; }
+
+    /// <summary>
+    /// Gets human readable full description for this command evaluator
+    /// functionality as formatted text.
+    /// </summary>
+    /// <remarks>The collection is to aid separation to paragraphs.</remarks>
+    ImmutableArray<SimpleMarkdownText> Doc { get; }
+
+    /// <summary>
+    /// Gets the version from which the command evaluator is available from.
+    /// </summary>
+    string Since { get; }
+
+    /// <summary>
+    /// Gets the change log of this evaluator, version
+    /// keyd summaries.
+    /// </summary>
+    ImmutableSortedDictionary<string, SimpleMarkdownText> ChangeLog { get; }
+
+    /// <summary>
+    /// Gets collection of subcommands. When called by user they
+    /// are preceded by this <see cref="Verb"/> (e.g. subcommand
+    /// with main verb 'SUB' of the command with the main verb 'BASE'
+    /// is visible to user as 'BASE SUB ...').
+    /// </summary>
+    ImmutableArray<ICommandEvaluator> Subs { get; }
+
+    /// <summary>
+    /// Enumerate all the aplicable verbs for this
+    /// evaluator, including any sub-evaluators.
+    /// E.g. ['BASE'], ['BASE', 'SUB'].
+    /// </summary>
+    /// <returns>Collection of command evaluator verbs. For simple
+    /// evaluator this is a collection of 1 item of <see cref="Verb"/>.
+    /// For composite evaluators this is a collection of multiple
+    /// items with items as arrays with <see cref="Verb"/> as the first
+    /// element followed by the verb of subcommands etc.</returns>
+    IEnumerable<CommandVerb[]> GetAllApplicableVerbs();
+}

--- a/src/Radicle.CLI/src/Evaluators/ICommandGroup.cs
+++ b/src/Radicle.CLI/src/Evaluators/ICommandGroup.cs
@@ -1,0 +1,12 @@
+namespace Radicle.CLI.Evaluators;
+
+/// <summary>
+/// Interface of the command evaluators group.
+/// </summary>
+public interface ICommandGroup
+{
+    /// <summary>
+    /// Gets the name of the command group.
+    /// </summary>
+    CommandGroupName Name { get; }
+}

--- a/src/Radicle.CLI/src/Evaluators/IEvaluationContext.cs
+++ b/src/Radicle.CLI/src/Evaluators/IEvaluationContext.cs
@@ -1,0 +1,24 @@
+﻿namespace Radicle.CLI.Evaluators;
+
+using Radicle.CLI.REPL;
+
+/// <summary>
+/// Command evaluator evaluation context.
+/// </summary>
+public interface IEvaluationContext
+{
+    /// <summary>
+    /// Gets current styling provider in use.
+    /// </summary>
+    IREPLStylingProvider StylingProvider { get; }
+
+    /// <summary>
+    /// Gets input history.
+    /// </summary>
+    IREPLInputHistory History { get; }
+
+    /// <summary>
+    /// Gets bundle of available commands.
+    /// </summary>
+    CommandEvaluatorBundle Commands { get; }
+}

--- a/src/Radicle.CLI/src/IO/HistoryReader.cs
+++ b/src/Radicle.CLI/src/IO/HistoryReader.cs
@@ -1,0 +1,207 @@
+namespace Radicle.CLI.IO;
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Radicle.Common.Check;
+
+/// <summary>
+/// Collection of history reading APIs.
+/// </summary>
+public static class HistoryReader
+{
+    /// <summary>
+    /// Gets default history file path.
+    /// </summary>
+    /// <param name="pathRelativeToHome">Path of the history file
+    ///     relative to user home directory.</param>
+    /// <returns>Path to default history file.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    public static string GetFilePath(string pathRelativeToHome)
+    {
+        string userPath = Environment.GetFolderPath(
+                Environment.SpecialFolder.UserProfile);
+
+        return Path.Combine(userPath, pathRelativeToHome);
+    }
+
+    /// <summary>
+    /// Try to read the history file at <paramref name="filePath"/>.
+    /// Fails silently in case the file can not be read or accessed.
+    /// </summary>
+    /// <param name="filePath">Path to read file from.</param>
+    /// <returns>Collection of history items. Can be empty.
+    /// First item is the oldest.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    /// <exception cref="PathTooLongException">Thrown
+    ///     if <paramref name="filePath"/> is too long.</exception>
+    /// <exception cref="NotSupportedException">Thrown
+    ///     if <paramref name="filePath"/> is in invalid format.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown
+    ///     if <paramref name="filePath"/> is empty.</exception>
+    /// <exception cref="ArgumentException">Thrown
+    ///     if <paramref name="filePath"/> contains only white spaces.</exception>
+    public static async Task<ICollection<string>> TryReadHistoryAsync(string filePath)
+    {
+        Ensure.Param(filePath).NotEmpty().NotWhiteSpace().Done();
+
+        try
+        {
+            using StreamReader stream = File.OpenText(filePath);
+
+            return await TryReadHistoryAsync(stream).ConfigureAwait(false);
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return Array.Empty<string>();
+        }
+        catch (FileNotFoundException)
+        {
+            return Array.Empty<string>();
+        }
+    }
+
+    /// <summary>
+    /// Try to write the history file at <paramref name="filePath"/>.
+    /// Fails silently in case the file can not be read or accessed.
+    /// </summary>
+    /// <param name="filePath">Path to write file to.</param>
+    /// <param name="history">History to write.</param>
+    /// <returns><see langword="true"/> if succesfully written.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    /// <exception cref="PathTooLongException">Thrown
+    ///     if <paramref name="filePath"/> is too long.</exception>
+    /// <exception cref="NotSupportedException">Thrown
+    ///     if <paramref name="filePath"/> is in invalid format.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown
+    ///     if <paramref name="filePath"/> is empty.</exception>
+    /// <exception cref="ArgumentException">Thrown
+    ///     if <paramref name="filePath"/> contains only white spaces.</exception>
+    public static async Task<bool> TryWriteHistoryAsync(
+            string filePath,
+            IEnumerable<string> history)
+    {
+        Ensure.Param(filePath).NotEmpty().NotWhiteSpace().Done();
+
+        try
+        {
+            using StreamWriter stream = File.CreateText(filePath);
+
+            await TryWriteHistoryAsync(stream, history).ConfigureAwait(false);
+
+            return true;
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+        catch (DirectoryNotFoundException)
+        {
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Try to append the history file at <paramref name="filePath"/>.
+    /// Fails silently in case the file can not be read or accessed.
+    /// </summary>
+    /// <param name="filePath">Path to write file to.</param>
+    /// <param name="historyPatch">History to write.</param>
+    /// <returns><see langword="true"/> if succesfully written.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    /// <exception cref="PathTooLongException">Thrown
+    ///     if <paramref name="filePath"/> is too long.</exception>
+    /// <exception cref="NotSupportedException">Thrown
+    ///     if <paramref name="filePath"/> is in invalid format.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown
+    ///     if <paramref name="filePath"/> is empty.</exception>
+    /// <exception cref="ArgumentException">Thrown
+    ///     if <paramref name="filePath"/> contains only white spaces.</exception>
+    public static async Task<bool> TryAppendHistoryAsync(
+            string filePath,
+            IEnumerable<string> historyPatch)
+    {
+        Ensure.Param(filePath).NotEmpty().NotWhiteSpace().Done();
+
+        try
+        {
+            using StreamWriter stream = File.AppendText(filePath);
+
+            await TryWriteHistoryAsync(stream, historyPatch).ConfigureAwait(false);
+
+            return true;
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+        catch (DirectoryNotFoundException)
+        {
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Try to read the history from the stream.
+    /// Fails silently in case the file can not be read or accessed.
+    /// </summary>
+    /// <param name="stream">Text stream.</param>
+    /// <returns>Collection of history items. Can be empty.</returns>
+    /// <exception cref="ArgumentNullException">Throw if
+    ///     required parameter is <see langword="null"/>.</exception>
+    public static async Task<ICollection<string>> TryReadHistoryAsync(
+            TextReader stream)
+    {
+        Ensure.Param(stream).Done();
+
+        List<string> result = new();
+
+        while (true)
+        {
+            try
+            {
+                string? line = await stream.ReadLineAsync().ConfigureAwait(false);
+
+                if (line is null)
+                {
+                    break;
+                }
+
+                result.Add(line);
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                // skip this line as it is too long
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Try to read the history from the stream.
+    /// Fails silently in case the file can not be read or accessed..
+    /// </summary>
+    /// <param name="stream">Text stream to write to.</param>
+    /// <param name="history">History to append.</param>
+    /// <returns>Collection of history items. Can be empty.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    public static async Task TryWriteHistoryAsync(
+            TextWriter stream,
+            IEnumerable<string> history)
+    {
+        Ensure.Param(stream).Done();
+        Ensure.Param(history).AllNotNull().Done();
+
+        foreach (string item in history)
+        {
+            await stream.WriteLineAsync(item).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Radicle.CLI/src/Models/EvaluationOutput.cs
+++ b/src/Radicle.CLI/src/Models/EvaluationOutput.cs
@@ -1,0 +1,211 @@
+﻿namespace Radicle.CLI.Models;
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using Radicle.Common.Check;
+using Radicle.Common.Tokenization;
+using Radicle.Common.Tokenization.Models;
+
+/// <summary>
+/// Printable output of the evaluation.
+/// </summary>
+public sealed class EvaluationOutput
+{
+    /// <summary>
+    /// No operation execution output.
+    /// </summary>
+    public static readonly EvaluationOutput NoOp = new(EvaluationOutputState.NoOp);
+
+    /// <summary>
+    /// Plain exit execution output.
+    /// </summary>
+    public static readonly EvaluationOutput Exit = new(EvaluationOutputState.Exit);
+
+    /// <summary>
+    /// No message (silent) error execution output
+    /// for cases when errors should be hidden because
+    /// they are expected due to nature of task (e.g. help
+    /// about non existing command or similar).
+    /// </summary>
+    public static readonly EvaluationOutput SilentError = new(EvaluationOutputState.Error);
+
+    private static readonly StopWordStringParser SimpleMarkdownStopWordStringParser = new(
+            stopWords: new HashSet<ParsedTokenStopWord>(new[]
+            {
+                SimpleMarkdownText.EmphasisedStopWord,
+                SimpleMarkdownText.BoldStopWord,
+                SimpleMarkdownText.EscapeStopWord,
+            }),
+            controlTokenAction: (state) =>
+            {
+                if (state.TriggeringStopWord == SimpleMarkdownText.EscapeStopWord)
+                {
+                    return ParseAction.ContinueWithControllUntil(1);
+                }
+
+                return ParseAction.Continue;
+            });
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EvaluationOutput"/> class.
+    /// </summary>
+    /// <param name="state">Type of the output.</param>
+    /// <param name="outputLines">Output lines data if any.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required argument is <see langword="null"/>.</exception>
+    private EvaluationOutput(
+            EvaluationOutputState state,
+            IEnumerable<OutputLine>? outputLines = null)
+    {
+        this.State = state;
+        this.OutputLines = Ensure.Optional(outputLines).AllNotNull().ToImmutableArray();
+    }
+
+    /// <summary>
+    /// Gets the state of the execution output.
+    /// </summary>
+    public EvaluationOutputState State { get; }
+
+    /// <summary>
+    /// Gets execution output payload.
+    /// </summary>
+    public ImmutableArray<OutputLine> OutputLines { get; }
+
+    /// <summary>
+    /// Creates success execution output.
+    /// </summary>
+    /// <param name="outputLines">Output lines data if any.</param>
+    /// <returns>instance of <see cref="EvaluationOutput"/>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required argument is <see langword="null"/>.</exception>
+    public static EvaluationOutput SuccessFrom(
+            IEnumerable<OutputLine>? outputLines = null)
+    {
+        return new EvaluationOutput(EvaluationOutputState.Success, outputLines);
+    }
+
+    /// <summary>
+    /// Creates success execution output.
+    /// </summary>
+    /// <param name="mds">Simple markdown if any.</param>
+    /// <returns>instance of <see cref="EvaluationOutput"/>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required argument is <see langword="null"/>.</exception>
+    public static EvaluationOutput SuccessFrom(
+            IEnumerable<SimpleMarkdownText> mds)
+    {
+        return new EvaluationOutput(
+                EvaluationOutputState.Success,
+                Ensure.Param(mds).AllNotNull().Select(md => Convert(md)));
+    }
+
+    /// <summary>
+    /// Creates success execution output.
+    /// </summary>
+    /// <param name="md">Simple markdown.</param>
+    /// <returns>instance of <see cref="EvaluationOutput"/>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required argument is <see langword="null"/>.</exception>
+    public static EvaluationOutput SuccessFrom(
+            SimpleMarkdownText md)
+    {
+        return SuccessFrom(new[] { md });
+    }
+
+    /// <summary>
+    /// Creates error output with simple message.
+    /// </summary>
+    /// <param name="message">Message as it is.</param>
+    /// <param name="exception">Optional exception.</param>
+    /// <returns>instance of <see cref="EvaluationOutput"/>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required argument is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown
+    ///     if parameters are empty.</exception>
+    /// <exception cref="ArgumentException">Thrown if parameters
+    ///     are white space or contain new lines.</exception>
+    public static EvaluationOutput ErrorFrom(
+            string message,
+            Exception? exception = null)
+    {
+        Ensure.Param(message)
+                .NotEmpty()
+                .NotWhiteSpace()
+                .NoNewLines().Done();
+
+        List<OutputLine> lines = new()
+        {
+            message,
+        };
+
+        if (exception is not null)
+        {
+            lines.AddRange(OutputLine.ToOutputLines(exception.ToString()));
+        }
+
+        return new EvaluationOutput(
+                EvaluationOutputState.Error,
+                lines);
+    }
+
+    /// <inheritdoc/>
+    public override string ToString()
+    {
+        StringBuilder sb = new StringBuilder($"{this.State}")
+            .AppendLine();
+
+        foreach (OutputLine line in this.OutputLines)
+        {
+            sb = sb.AppendLine(line.ToString());
+        }
+
+        return sb.ToString();
+    }
+
+    private static OutputLine Convert(SimpleMarkdownText md)
+    {
+        List<OutputSnippet> snippets = new();
+        OutputStyle nextStyle = OutputStyle.Normal;
+
+        foreach (ParsedToken token in SimpleMarkdownStopWordStringParser.Parse(md.Value))
+        {
+            if (token is ParsedTokenControl escape)
+            {
+                snippets.Add(new OutputSnippet(nextStyle, escape.Value));
+            }
+            else if (token is ParsedTokenStopWord stop)
+            {
+                if (nextStyle == OutputStyle.Normal)
+                {
+                    if (stop == SimpleMarkdownText.BoldStopWord)
+                    {
+                        nextStyle = OutputStyle.Bold;
+                    }
+                    else if (stop == SimpleMarkdownText.EmphasisedStopWord)
+                    {
+                        nextStyle = OutputStyle.Emphasized;
+                    }
+                }
+                else if (
+                        (stop == SimpleMarkdownText.BoldStopWord
+                            && nextStyle == OutputStyle.Bold)
+                        || (stop == SimpleMarkdownText.EmphasisedStopWord
+                            && nextStyle == OutputStyle.Emphasized))
+                {
+                    nextStyle = OutputStyle.Normal;
+                }
+            }
+            else
+            {
+                snippets.Add(new OutputSnippet(nextStyle, token.Value));
+            }
+        }
+
+        return new OutputLine(snippets, OutputSnippetSeparator.Empty);
+    }
+
+    /* TODO: add other conversions */
+}

--- a/src/Radicle.CLI/src/Models/EvaluationOutputPromise.cs
+++ b/src/Radicle.CLI/src/Models/EvaluationOutputPromise.cs
@@ -1,0 +1,52 @@
+﻿namespace Radicle.CLI.Models;
+
+using System;
+using System.Threading.Tasks;
+using Radicle.Common;
+using Radicle.Common.Check;
+
+/// <summary>
+/// Promise of <see cref="EvaluationOutput"/>.
+/// </summary>
+public sealed class EvaluationOutputPromise
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EvaluationOutputPromise"/> class.
+    /// </summary>
+    /// <param name="promise">Awaitable task
+    ///     yielding <see cref="EvaluationOutput"/>.</param>
+    /// <param name="progress">Optiona progress instance.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    public EvaluationOutputPromise(
+            Task<EvaluationOutput> promise,
+            TransparentProgress<long>? progress = null)
+    {
+        this.Promise = Ensure.Param(promise).Value;
+        this.Progress = progress ?? new TransparentProgress<long>();
+    }
+
+    /// <summary>
+    /// Gets progress of the promise.
+    /// </summary>
+    public TransparentProgress<long> Progress { get; }
+
+    /// <summary>
+    /// Gets promise, awaitable task, yielding <see cref="EvaluationOutput"/>.
+    /// </summary>
+    public Task<EvaluationOutput> Promise { get; }
+
+    /// <summary>
+    /// Return completed instance.
+    /// </summary>
+    /// <param name="output">Output of completed promise.</param>
+    /// <returns>Instance of completed <see cref="EvaluationOutputPromise"/>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required paramter is <see langword="null"/>.</exception>
+    public static EvaluationOutputPromise Completed(EvaluationOutput output)
+    {
+        Ensure.Param(output).Done();
+
+        return new EvaluationOutputPromise(Task.FromResult(output));
+    }
+}

--- a/src/Radicle.CLI/src/Models/EvaluationOutputState.cs
+++ b/src/Radicle.CLI/src/Models/EvaluationOutputState.cs
@@ -1,0 +1,27 @@
+﻿namespace Radicle.CLI.Models;
+
+/// <summary>
+/// Enumeration of possible session command outputs.
+/// </summary>
+public enum EvaluationOutputState
+{
+    /// <summary>
+    /// No operation output.
+    /// </summary>
+    NoOp = 0,
+
+    /// <summary>
+    /// Request for termination.
+    /// </summary>
+    Exit = 1,
+
+    /// <summary>
+    /// Error output.
+    /// </summary>
+    Error = 2,
+
+    /// <summary>
+    /// Success output.
+    /// </summary>
+    Success = 3,
+}

--- a/src/Radicle.CLI/src/Models/EvaluationRawOutputPromise.cs
+++ b/src/Radicle.CLI/src/Models/EvaluationRawOutputPromise.cs
@@ -1,0 +1,66 @@
+﻿namespace Radicle.CLI.Models;
+
+using System;
+using System.Threading.Tasks;
+using Radicle.Common;
+using Radicle.Common.Check;
+
+/// <summary>
+/// Promise of <typeparamref name="T"/>.
+/// </summary>
+/// <typeparam name="T">Type of the evaluation output payload.</typeparam>
+public sealed class EvaluationRawOutputPromise<T>
+    where T : notnull
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EvaluationRawOutputPromise{T}"/> class.
+    /// </summary>
+    /// <param name="promise">Awaitable task
+    ///     yielding <typeparamref name="T"/>.</param>
+    /// <param name="progress">Optiona progress instance.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    public EvaluationRawOutputPromise(
+            Task<T> promise,
+            TransparentProgress<long>? progress = null)
+    {
+        this.Promise = Ensure.Param(promise).Value;
+        this.Progress = progress ?? new TransparentProgress<long>();
+    }
+
+    /// <summary>
+    /// Gets progress of the promise.
+    /// </summary>
+    public TransparentProgress<long> Progress { get; }
+
+    /// <summary>
+    /// Gets promise, awaitable task, yielding <typeparamref name="T"/>.
+    /// </summary>
+    public Task<T> Promise { get; }
+
+#pragma warning disable CA1000 // Do not declare static members on generic types
+    /// <summary>
+    /// Implicit conversion from the instance of <see cref="EvaluationRawOutputPromise{T}"/>.
+    /// </summary>
+    /// <param name="payload">Execution output to convert to fulfilled promisse.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    public static implicit operator EvaluationRawOutputPromise<T>(T payload)
+    {
+        return ToEvaluationRawOutputPromise(payload);
+    }
+
+    /// <summary>
+    /// Conversion from the instance of <see cref="EvaluationRawOutputPromise{T}"/>.
+    /// </summary>
+    /// <param name="payload">Output to convert to fulfilled promisse.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    /// <returns>Instance of <see cref="EvaluationRawOutputPromise{T}"/>.</returns>
+    public static EvaluationRawOutputPromise<T> ToEvaluationRawOutputPromise(
+            T payload)
+    {
+        return new EvaluationRawOutputPromise<T>(Task.FromResult(Ensure.Param(payload).Value));
+    }
+#pragma warning restore CA1000 // Do not declare static members on generic types
+}

--- a/src/Radicle.CLI/src/Models/OutputLine.cs
+++ b/src/Radicle.CLI/src/Models/OutputLine.cs
@@ -1,0 +1,134 @@
+namespace Radicle.CLI.Models;
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using Radicle.Common;
+using Radicle.Common.Check;
+
+/// <summary>
+/// Immutable model of printable output line
+/// ususally printed on some form of console.
+/// </summary>
+public sealed class OutputLine : IEnumerable<OutputSnippet>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OutputLine"/> class.
+    /// </summary>
+    /// <param name="snippets">Snippets.</param>
+    /// <param name="separator">Seprator preference, defaults to none.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    public OutputLine(
+            IEnumerable<OutputSnippet> snippets,
+            OutputSnippetSeparator separator = OutputSnippetSeparator.Empty)
+    {
+        this.Snippets = Ensure.Param(snippets)
+                .AllNotNull()
+                .ToImmutableArray();
+        this.Separator = separator;
+    }
+
+    /// <summary>
+    /// Gets snippets this line is made of.
+    /// </summary>
+    public ImmutableArray<OutputSnippet> Snippets { get; }
+
+    /// <summary>
+    /// Gets a value indicating what separator should be used.
+    /// </summary>
+    public OutputSnippetSeparator Separator { get; }
+
+    /// <summary>
+    /// Implicitly convert raw string to line as a single snippet.
+    /// </summary>
+    /// <param name="snippetString">Raw string.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown
+    ///     if <paramref name="snippetString"/> contains new lines.</exception>
+    public static implicit operator OutputLine(string snippetString)
+    {
+        return ToOutputLine(snippetString);
+    }
+
+    /// <summary>
+    /// Convert raw string to line.
+    /// </summary>
+    /// <param name="snippetString">Raw string.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown
+    ///     if <paramref name="snippetString"/> contains new lines.</exception>
+    /// <returns>Instance of <see cref="OutputLine"/>.</returns>
+    public static OutputLine ToOutputLine(string snippetString)
+    {
+        return new OutputLine(new[] { (OutputSnippet)snippetString });
+    }
+
+    /// <summary>
+    /// Convert raw strings to line.
+    /// </summary>
+    /// <param name="snippetStrings">Raw strings.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown
+    ///     if <paramref name="snippetStrings"/> contains new lines.</exception>
+    /// <returns>Instance of <see cref="OutputLine"/>.</returns>
+    public static IEnumerable<OutputLine> ToOutputLines(IEnumerable<string> snippetStrings)
+    {
+        return Ensure.Param(snippetStrings)
+                .AllNotNull()
+                .Select(s => new OutputLine(new[] { (OutputSnippet)s }));
+    }
+
+    /// <summary>
+    /// Convert raw strings to line.
+    /// </summary>
+    /// <param name="multilineString">Raw strings.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown
+    ///     if <paramref name="multilineString"/> contains new lines.</exception>
+    /// <returns>Instance of <see cref="OutputLine"/>.</returns>
+    public static IEnumerable<OutputLine> ToOutputLines(string multilineString)
+    {
+        Ensure.Param(multilineString).Done();
+
+        return ToOutputLines(
+                multilineString.Split(
+                    new[] { "\n", "\r" },
+                    StringSplitOptions.RemoveEmptyEntries));
+    }
+
+    /// <inheritdoc/>
+    public IEnumerator<OutputSnippet> GetEnumerator()
+    {
+        return ((IEnumerable<OutputSnippet>)this.Snippets).GetEnumerator();
+    }
+
+    /// <inheritdoc/>
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return this.GetEnumerator();
+    }
+
+    /// <inheritdoc/>
+    public override string ToString()
+    {
+        StringBuilder sb = new();
+
+        foreach (OutputSnippet snipet in this)
+        {
+            sb = sb.Append('[')
+                    .Append(snipet.Style)
+                    .Append("] ")
+                    .Append(Dump.Literal(snipet.Value));
+        }
+
+        return sb.ToString();
+    }
+}

--- a/src/Radicle.CLI/src/Models/OutputSnippet.cs
+++ b/src/Radicle.CLI/src/Models/OutputSnippet.cs
@@ -1,0 +1,64 @@
+﻿namespace Radicle.CLI.Models;
+
+using System;
+using Radicle.Common.Check;
+
+/// <summary>
+/// Immutable model of elementary output snippet, ususally part of line.
+/// </summary>
+public sealed class OutputSnippet
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OutputSnippet"/> class.
+    /// </summary>
+    /// <param name="style">Style of the <paramref name="value"/>.</param>
+    /// <param name="value">Text new line free value of the snippet.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown
+    ///     if <paramref name="value"/> contains new lines.</exception>
+    public OutputSnippet(
+            OutputStyle style,
+            string value)
+    {
+        this.Style = style;
+        this.Value = Ensure.Param(value).NoNewLines().Value;
+    }
+
+    /// <summary>
+    /// Gets style of the snippet.
+    /// </summary>
+    public OutputStyle Style { get; }
+
+    /// <summary>
+    /// Gets value of the snippet, can be empty string.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Implicit conversion of raw string to snippet.
+    /// </summary>
+    /// <param name="value">Value to convert.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown
+    ///     if <paramref name="value"/> contains new lines.</exception>
+    public static implicit operator OutputSnippet(string value)
+    {
+        return ToOutputSnippet(value);
+    }
+
+    /// <summary>
+    /// Conversion of raw string to snippet.
+    /// </summary>
+    /// <param name="value">Value to convert.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown
+    ///     if <paramref name="value"/> contains new lines.</exception>
+    /// <returns>Instance of <see cref="OutputSnippet"/>.</returns>
+    public static OutputSnippet ToOutputSnippet(string value)
+    {
+        return new OutputSnippet(OutputStyle.Normal, value);
+    }
+}

--- a/src/Radicle.CLI/src/Models/OutputSnippetSeparator.cs
+++ b/src/Radicle.CLI/src/Models/OutputSnippetSeparator.cs
@@ -1,0 +1,17 @@
+﻿namespace Radicle.CLI.Models;
+
+/// <summary>
+/// Enumeration of allowd snipped separators.
+/// </summary>
+public enum OutputSnippetSeparator
+{
+    /// <summary>
+    /// No separator.
+    /// </summary>
+    Empty = 0,
+
+    /// <summary>
+    /// Space separator.
+    /// </summary>
+    Space = 1,
+}

--- a/src/Radicle.CLI/src/Models/OutputStyle.cs
+++ b/src/Radicle.CLI/src/Models/OutputStyle.cs
@@ -1,0 +1,27 @@
+﻿namespace Radicle.CLI.Models;
+
+/// <summary>
+/// Enumeration of output styles.
+/// </summary>
+public enum OutputStyle
+{
+    /// <summary>
+    /// Normal style of output for general text.
+    /// </summary>
+    Normal = 0,
+
+    /// <summary>
+    /// Bold style.
+    /// </summary>
+    Bold = 1,
+
+    /// <summary>
+    /// Less or no-bold, emphasized style.
+    /// </summary>
+    Emphasized = 2,
+
+    /// <summary>
+    /// Comment style of output for any coments.
+    /// </summary>
+    Comment = 3,
+}

--- a/src/Radicle.CLI/src/Models/ProgressBars.cs
+++ b/src/Radicle.CLI/src/Models/ProgressBars.cs
@@ -1,0 +1,109 @@
+﻿namespace Radicle.CLI.Models;
+
+using System;
+using System.Collections.Immutable;
+
+/// <summary>
+/// Collection of various progress bars for showing
+/// bound progress. Note the edge characters
+/// are also included on first and last positions.
+/// </summary>
+internal static class ProgressBars
+{
+    /// <summary>
+    /// ASCII progress bars.
+    /// </summary>
+    public static readonly ImmutableArray<char> ASCII = new[]
+    {
+        '[',
+        ' ',
+        ':',
+        '|',
+        'I',
+        ']',
+    }.ToImmutableArray();
+
+    /// <summary>
+    /// Classic full vertical block progress bars.
+    /// </summary>
+    public static readonly ImmutableArray<char> FullVerticalBlock = new[]
+    {
+        '\u2595',
+        ' ',
+        '\u258F',
+        '\u258E',
+        '\u258D',
+        '\u258C',
+        '\u258B',
+        '\u258A',
+        '\u2589',
+        '\u2588', // full block
+        '\u258F',
+    }.ToImmutableArray();
+
+    /// <summary>
+    /// Partial block progress bars.
+    /// </summary>
+    public static readonly ImmutableArray<char> PartialBlock = new[]
+    {
+        '\u2595',
+        ' ',
+        '\u2596',
+        '\u258C',
+        '\u2599',
+        '\u2588', // full block
+        '\u258F',
+    }.ToImmutableArray();
+
+    /// <summary>
+    /// Braille dots progress bars.
+    /// </summary>
+    public static readonly ImmutableArray<char> BlockDots = new[]
+    {
+        '\u28B8',
+        ' ',
+        '\u2801',
+        '\u2803',
+        '\u2807',
+        '\u2847',
+        '\u284F',
+        '\u285F',
+        '\u287F',
+        '\u28FF',
+        '\u2847',
+    }.ToImmutableArray();
+
+    /// <summary>
+    /// Horizontal ots progress bars.
+    /// </summary>
+    public static readonly ImmutableArray<char> Dots = new[]
+    {
+        '(',
+        ' ',
+        '.',
+        '\u2025', // two dot leader
+        '\u2026', // ellipsis
+        ')',
+    }.ToImmutableArray();
+
+    /// <summary>
+    /// Return bars for given <paramref name="type"/>.
+    /// </summary>
+    /// <param name="type">Type of the bars.</param>
+    /// <returns>Progress bars characters, first and last
+    ///     character are bounding characters.</returns>
+    /// <exception cref="NotSupportedException">Thrown in case of bug.</exception>
+    public static ImmutableArray<char> GetBars(
+            ProgressBarsType type)
+    {
+        return type switch
+        {
+            ProgressBarsType.ASCII => ASCII,
+            ProgressBarsType.Graphic => FullVerticalBlock,
+            ProgressBarsType.PartialBlock => PartialBlock,
+            ProgressBarsType.BlockDots => BlockDots,
+            ProgressBarsType.Dots => Dots,
+            _ => throw new NotSupportedException($"BUG: progress type {type} is unknown."),
+        };
+    }
+}

--- a/src/Radicle.CLI/src/Models/ProgressBarsType.cs
+++ b/src/Radicle.CLI/src/Models/ProgressBarsType.cs
@@ -1,0 +1,33 @@
+﻿namespace Radicle.CLI.Models;
+
+/// <summary>
+/// Enumeration of types of progress bars.
+/// </summary>
+public enum ProgressBarsType
+{
+    /// <summary>
+    /// ASCII based progress bars.
+    /// </summary>
+    ASCII = 0,
+
+    /// <summary>
+    /// Graphic full vertical bars based progress bars
+    /// or platform based progress bars.
+    /// </summary>
+    Graphic = 1,
+
+    /// <summary>
+    /// Block based progress bars.
+    /// </summary>
+    PartialBlock = 2,
+
+    /// <summary>
+    /// Braille based progress bars.
+    /// </summary>
+    BlockDots = 3,
+
+    /// <summary>
+    /// Dots/period progress bars.
+    /// </summary>
+    Dots = 4,
+}

--- a/src/Radicle.CLI/src/Models/ProgressViewModel.cs
+++ b/src/Radicle.CLI/src/Models/ProgressViewModel.cs
@@ -1,0 +1,241 @@
+﻿namespace Radicle.CLI.Models;
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Text;
+using Radicle.Common;
+using Radicle.Common.Check;
+using Radicle.Common.Extensions;
+
+/// <summary>
+/// Immutable progress model used for REPL
+/// with string representations.
+/// </summary>
+internal sealed class ProgressViewModel
+{
+    private readonly ImmutableArray<char> spinner;
+
+    private readonly ImmutableArray<char> progressBars;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ProgressViewModel"/> class.
+    /// </summary>
+    /// <param name="count">Current count.</param>
+    /// <param name="spinner">Spinner containing consecutively displayed characters.</param>
+    /// <param name="progressBars">Progress bars characters, first and last
+    ///     items are treated as bounding characters. Inside items
+    ///     are treated as characters representing empty to full state (thus minimu 2).
+    ///     E.g.: ['(', ' ', '.', '_', ')'] will result in 50% progress displayed as:
+    ///     "(___.   )".</param>
+    /// <param name="totalCount">Optional total amount of items.</param>
+    /// <param name="duration">Elapsed time from start of the progress.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown
+    ///     if <paramref name="spinner"/> is out of [2, 42] range;
+    ///     or <paramref name="progressBars"/> is out of [4, 42] range.</exception>
+    public ProgressViewModel(
+            ulong count,
+            IEnumerable<char> spinner,
+            IEnumerable<char> progressBars,
+            ulong? totalCount = null,
+            TimeSpan? duration = null)
+    {
+        this.Count = count;
+        this.Total = totalCount.HasValue ? Math.Max(count, totalCount.Value) : totalCount;
+        this.Elapsed = Ensure.Optional(duration)
+                .NonNegative()
+                .ValueOr(TimeSpan.Zero);
+        this.spinner = Ensure.Collection(spinner).InRange(2, 42).ToImmutableArray();
+        this.progressBars = Ensure.Collection(progressBars).InRange(4, 42).ToImmutableArray();
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ProgressViewModel"/> class.
+    /// </summary>
+    /// <param name="progress">Progress source, values are clipped if required.</param>
+    /// <param name="spinner">Spinner containing consecutively displayed characters.</param>
+    /// <param name="progressBars">Progress bars characters, first and last
+    ///     items are treated as bounding characters. Inside items
+    ///     are treated as characters representing empty to full state (thus minimu 2).
+    ///     E.g.: ['(', ' ', '.', '_', ')'] will result in 50% progress displayed as:
+    ///     "(____.   )".</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown
+    ///     if <paramref name="spinner"/> is out of [2, 42] range;
+    ///     or <paramref name="progressBars"/> is out of [4, 42] range.</exception>
+    public ProgressViewModel(
+            TransparentProgress<long> progress,
+            ImmutableArray<char> spinner,
+            ImmutableArray<char> progressBars)
+    {
+        Ensure.Param(progress).Done();
+
+        this.Count = progress.Count < 0L
+                ? 0uL
+                : (ulong)progress.Count;
+        this.Total = (progress.Total >= 0L)
+                ? Math.Max(this.Count, (ulong)progress.Total)
+                : 0uL;
+        this.Elapsed = (DateTimeOffset.UtcNow - progress.StartDate).UseIfLongerOr(TimeSpan.Zero);
+        this.spinner = Ensure.Collection(spinner).InRange(2, 42).ToImmutableArray();
+        this.progressBars = Ensure.Collection(progressBars).InRange(4, 42).ToImmutableArray();
+    }
+
+    /// <summary>
+    /// Gets current count.
+    /// </summary>
+    public ulong Count { get; }
+
+    /// <summary>
+    /// Gets current known total, if known.
+    /// The amount is never smaller than <see cref="Count"/>.
+    /// </summary>
+    public ulong? Total { get; }
+
+    /// <summary>
+    /// Gets elapsed time from the start.
+    /// Can be zero.
+    /// </summary>
+    public TimeSpan Elapsed { get; }
+
+    /// <summary>
+    /// Gets estimated time of arrival.
+    /// </summary>
+    public TimeSpan ETA
+    {
+        get
+        {
+            double multiplier = (1.0 - this.Ratio) / this.Ratio;
+            TimeSpan maximumETA = TimeSpan.FromDays(365 * 2);
+
+            if (double.IsInfinity(multiplier))
+            {
+                return maximumETA;
+            }
+
+            // time span multiplication can overflow
+            // with System.OverflowException unlike:
+            double elapsed = this.Elapsed.TotalSeconds;
+            double eta = elapsed * multiplier;
+
+            if (maximumETA.TotalSeconds <= eta)
+            {
+                return maximumETA;
+            }
+
+            return TimeSpan.FromSeconds(eta);
+        }
+    }
+
+    /// <summary>
+    /// Gets current progress ration.
+    /// </summary>
+    public double Ratio => this.Total.HasValue && this.Total != 0
+            ? (double)this.Count / this.Total.Value
+            : 1.0;
+
+    /// <summary>
+    /// Convert this instance to printable string.
+    /// </summary>
+    /// <param name="requestCounter">Request counter
+    ///     to determine spinner position. Each time
+    ///     you call this method increment the counter by 1.</param>
+    /// <returns>String representation.</returns>
+    public string ToString(ulong requestCounter = 0)
+    {
+        ImmutableArray<char> spinnerChars = this.spinner;
+        char spinner = spinnerChars[(int)(requestCounter % (ulong)spinnerChars.Length)];
+
+        return new StringBuilder(spinner.ToString())
+                .Append(' ')
+                .Append(this.GetProgressOrCurrentCount())
+                .Append(' ')
+                .Append(this.SpeedOrEmpty())
+                .Append("; ")
+                .Append(this.GetETAOrElapsedTime())
+                .ToString();
+    }
+
+    private string GetETAOrElapsedTime()
+    {
+        if (this.Total.HasValue && this.Total.Value != 0)
+        {
+            return $"ETA {this.ETA.ToH()}";
+        }
+
+        return this.Elapsed.ToHuman();
+    }
+
+    private string GetProgressOrCurrentCount()
+    {
+        // progress in bars/percentage
+        if (this.Total.HasValue && this.Total.Value != 0)
+        {
+            string total = $"{this.Total ?? '?'}";
+            string count = $"{this.Count}".PadLeft(total.Length);
+            string counts = $"{count}/{total}";
+
+            return $"{counts} {this.GetProgressBars(this.Ratio, 12)}";
+        }
+
+        // just count
+        return $"{this.Count}";
+    }
+
+    private string GetProgressBars(
+            double ratio,
+            ushort barWidth)
+    {
+        ratio = ratio < 0.0 ? 0.0 : ratio;
+        ratio = ratio > 1.0 ? 1.0 : ratio;
+        int effectiveLength = this.progressBars.Length - 2;
+        int fill = (int)Math.Round(barWidth * effectiveLength * ratio, MidpointRounding.AwayFromZero);
+        int full = fill / effectiveLength;
+        int partial = fill % effectiveLength;
+
+        // add opening boundary
+        StringBuilder sb = new StringBuilder()
+                .Append(this.progressBars[0]);
+
+        // fill with full characters
+        for (int i = 0; i < barWidth; i++)
+        {
+            if (i < full)
+            {
+                sb = sb.Append(this.progressBars[^2]);
+            }
+        }
+
+        // pad with partial fraction character
+        if (sb.Length < barWidth)
+        {
+            sb = sb.Append(this.progressBars[1 + partial]);
+        }
+
+        // pad with empty characters
+        while (sb.Length < barWidth)
+        {
+            sb = sb.Append(this.progressBars[1]);
+        }
+
+        // add closing boundary
+        sb = sb.Append(this.progressBars[^1]);
+
+        return sb.ToString();
+    }
+
+    private string SpeedOrEmpty()
+    {
+        if (this.Elapsed != TimeSpan.Zero)
+        {
+            double speed = this.Count / this.Elapsed.TotalSeconds;
+
+            return $"({speed:f0} ops/s)";
+        }
+
+        return string.Empty;
+    }
+}

--- a/src/Radicle.CLI/src/Models/PromptViewModel.cs
+++ b/src/Radicle.CLI/src/Models/PromptViewModel.cs
@@ -1,0 +1,321 @@
+namespace Radicle.CLI.Models;
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using Radicle.Common.Check;
+
+/// <summary>
+/// View model of the user prompt.
+/// </summary>
+internal sealed class PromptViewModel
+{
+    /*
+     Composition of the prompt:
+
+     ps1_value > very long ][ user input [with auto suggestion tail]
+     \_________/\_________/|'\__________/\_________________________/
+          |         |      |      |                 `- interactive suggestion
+          |         |      |      |                    (displayed with different style then input)
+          |         |      |      `-right side of user written input
+          |         |      `- cursor (of zero width in model) placed in user input
+          |         `- left side of user written input
+          `- prompt string one (fixed before user input)
+     */
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PromptViewModel"/> class.
+    /// </summary>
+    /// <param name="promptStringOne">Prompt string one.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    public PromptViewModel(string promptStringOne)
+    {
+        this.PromptStringOne = Ensure.Param(promptStringOne).ToImmutableArray();
+        this.InputHead = ImmutableStack<char>.Empty;
+        this.InputTail = ImmutableStack<char>.Empty;
+        this.SuggestionTail = ImmutableArray<char>.Empty;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PromptViewModel"/> class.
+    /// </summary>
+    /// <param name="promptStringOne">Prompt string one.</param>
+    /// <param name="inputHead">Input head.</param>
+    /// <param name="inputTail">Input tail.</param>
+    /// <param name="suggestionTail">Suggestion tail.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    private PromptViewModel(
+            ImmutableArray<char> promptStringOne,
+            ImmutableStack<char> inputHead,
+            ImmutableStack<char> inputTail,
+            ImmutableArray<char> suggestionTail)
+    {
+        this.PromptStringOne = promptStringOne;
+        this.InputHead = inputHead;
+        this.InputTail = inputTail;
+        this.SuggestionTail = suggestionTail;
+    }
+
+    /// <summary>
+    /// Gets prompt string one characters.
+    /// </summary>
+    public ImmutableArray<char> PromptStringOne { get; }
+
+    /// <summary>
+    /// Gets inout head characters.
+    /// </summary>
+    public ImmutableStack<char> InputHead { get; }
+
+    /// <summary>
+    /// Gets inout tail characters.
+    /// </summary>
+    public ImmutableStack<char> InputTail { get; }
+
+    /// <summary>
+    /// Gets suggection tail characters.
+    /// </summary>
+    public ImmutableArray<char> SuggestionTail { get; }
+
+    /// <summary>
+    /// Gets length till head.
+    /// </summary>
+    public int TillHeadLength => this.PromptStringOne.Length + this.InputHead.Count();
+
+    /// <summary>
+    /// Gets length till tail.
+    /// </summary>
+    public int TillTailLength => this.TillHeadLength + this.InputTail.Count();
+
+    /// <summary>
+    /// Gets total length.
+    /// </summary>
+    public int TotalLength => this.TillTailLength + this.SuggestionTail.Length;
+
+    /// <summary>
+    /// Gets current input value.
+    /// </summary>
+    public string UserInputValue
+    {
+        get
+        {
+            StringBuilder sb = new();
+
+            foreach (char c in this.InputHead.Reverse())
+            {
+                _ = sb.Append(c);
+            }
+
+            foreach (char c in this.InputTail)
+            {
+                _ = sb.Append(c);
+            }
+
+            return sb.ToString();
+        }
+    }
+
+    /// <summary>
+    /// Write given <paramref name="character"/>
+    /// at current cursor position to user input.
+    /// </summary>
+    /// <param name="character">Character to write.</param>
+    /// <returns>New instance of <see cref="PromptViewModel"/>.</returns>
+    public PromptViewModel Write(char character)
+    {
+        return new PromptViewModel(
+                this.PromptStringOne,
+                this.InputHead.Push(character),
+                this.InputTail,
+                this.SuggestionTail);
+    }
+
+    /// <summary>
+    /// Write given <paramref name="characters"/>
+    /// at current cursor position to user input.
+    /// </summary>
+    /// <param name="characters">Characters to write.</param>
+    /// <returns>New model.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    public PromptViewModel Write(string characters)
+    {
+        Ensure.Param(characters).Done();
+
+        if (characters.Length == 0)
+        {
+            return this;
+        }
+
+        ImmutableStack<char> head = this.InputHead;
+
+        foreach (char c in characters)
+        {
+            head = head.Push(c);
+        }
+
+        return new PromptViewModel(
+                this.PromptStringOne,
+                head,
+                this.InputTail,
+                this.SuggestionTail);
+    }
+
+    /// <summary>
+    /// Remove character on left from the cursor.
+    /// </summary>
+    /// <returns>New model.</returns>
+    public PromptViewModel BackDelete()
+    {
+        if (this.InputHead.IsEmpty)
+        {
+            return this;
+        }
+
+        return new PromptViewModel(
+                this.PromptStringOne,
+                this.InputHead.Pop(),
+                this.InputTail,
+                this.SuggestionTail);
+    }
+
+    /// <summary>
+    /// Remove character on right from the cursor.
+    /// </summary>
+    /// <returns>New model.</returns>
+    public PromptViewModel ForwardDelete()
+    {
+        if (this.InputTail.IsEmpty)
+        {
+            return this;
+        }
+
+        return new PromptViewModel(
+                this.PromptStringOne,
+                this.InputHead,
+                this.InputTail.Pop(),
+                this.SuggestionTail);
+    }
+
+    /// <summary>
+    /// Move cursor to left if possible.
+    /// </summary>
+    /// <returns>New instance of <see cref="PromptViewModel"/>
+    ///     or existing if cursor reached edge of input.</returns>
+    public PromptViewModel MoveCursorLeft()
+    {
+        if (this.InputHead.IsEmpty)
+        {
+            return this;
+        }
+
+        return new PromptViewModel(
+                this.PromptStringOne,
+                this.InputHead.Pop(out char c),
+                this.InputTail.Push(c),
+                this.SuggestionTail);
+    }
+
+    /// <summary>
+    /// Move cursor to right if possible.
+    /// </summary>
+    /// <returns>New instance of <see cref="PromptViewModel"/>
+    ///     or existing if cursor reached edge of input.</returns>
+    public PromptViewModel MoveCursorRight()
+    {
+        if (this.InputTail.IsEmpty)
+        {
+            return this;
+        }
+
+        ImmutableStack<char> newTail = this.InputTail.Pop(out char c);
+
+        return new PromptViewModel(
+                this.PromptStringOne,
+                this.InputHead.Push(c),
+                newTail,
+                this.SuggestionTail);
+    }
+
+    /// <summary>
+    /// Set suggestion tail.
+    /// </summary>
+    /// <param name="suggestionTail">Suggestion tail.</param>
+    /// <returns>New instance of <see cref="PromptViewModel"/>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    public PromptViewModel WithSuggestionTail(string suggestionTail)
+    {
+        Ensure.Param(suggestionTail).Done();
+
+        if (suggestionTail.Length == 0 && this.SuggestionTail.Length == 0)
+        {
+            return this;
+        }
+
+        return new PromptViewModel(
+                this.PromptStringOne,
+                this.InputHead,
+                this.InputTail,
+                suggestionTail.ToImmutableArray());
+    }
+
+    /// <summary>
+    /// Get expected position of cursor after the prefix and head.
+    /// </summary>
+    /// <param name="maxWidthConstrain">Constrains on the width,
+    ///     text will be wrapped if longer than constrain.</param>
+    /// <returns>Coordinated and total amount of printable lines (at least 1).</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown
+    ///     if <paramref name="maxWidthConstrain"/> non positive number.</exception>
+    public (int Left, int Top, int Lines) GetCursorPosition(int maxWidthConstrain)
+    {
+        return GetPosition(this.TillHeadLength, maxWidthConstrain);
+    }
+
+    /// <summary>
+    /// Get expected position of cursor after the total print out.
+    /// </summary>
+    /// <param name="maxWidthConstrain">Constrains on the width,
+    ///     text will be wrapped if longer than constrain.</param>
+    /// <returns>Coordinated and total amount of printable lines (at least 1).</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown
+    ///     if <paramref name="maxWidthConstrain"/> non positive number.</exception>
+    public (int Left, int Top, int Lines) GetPrintOutPosition(int maxWidthConstrain)
+    {
+        return GetPosition(this.TotalLength, maxWidthConstrain);
+    }
+
+    private static (int Left, int Top, int Lines) GetPosition(int length, int widthConstrain)
+    {
+        Ensure.Param(length).NonNegative().Done();
+        Ensure.Param(widthConstrain).StrictlyPositive().Done();
+
+        int lines = (length / widthConstrain)
+                + ((length % widthConstrain) == 0 ? 0 : 1);
+
+        if (lines == 0)
+        {
+            lines = 1;
+        }
+
+        int left = length % widthConstrain;
+        int top = lines - 1;
+
+        if (length == 0)
+        {
+            // special case of zero
+            top = 0;
+        }
+        else if (left == 0)
+        {
+            // when text fits perfectly to constrain
+            // we need to wrap around
+            top = lines;
+        }
+
+        return (left, top, lines);
+    }
+}

--- a/src/Radicle.CLI/src/Models/SpinnerType.cs
+++ b/src/Radicle.CLI/src/Models/SpinnerType.cs
@@ -1,0 +1,37 @@
+﻿namespace Radicle.CLI.Models;
+
+/// <summary>
+/// Enumeraion of all spinnner types.
+/// </summary>
+public enum SpinnerType
+{
+    /// <summary>
+    /// ASCII based spinner.
+    /// </summary>
+    ASCII = 0,
+
+    /// <summary>
+    /// Graphic arc or platform based spinner.
+    /// </summary>
+    Graphic = 1,
+
+    /// <summary>
+    /// Braille based shuffle spinner.
+    /// </summary>
+    Shuffle = 2,
+
+    /// <summary>
+    /// Braile based snake like spinner.
+    /// </summary>
+    Snake = 3,
+
+    /// <summary>
+    /// Block based spinner.
+    /// </summary>
+    Corners = 4,
+
+    /// <summary>
+    /// Circle based spinner.
+    /// </summary>
+    Circle = 5,
+}

--- a/src/Radicle.CLI/src/Models/Spinners.cs
+++ b/src/Radicle.CLI/src/Models/Spinners.cs
@@ -1,0 +1,110 @@
+﻿namespace Radicle.CLI.Models;
+
+using System;
+using System.Collections.Immutable;
+
+/// <summary>
+/// Collection of various spinners for showing
+/// unbound progress or that something is not frozen.
+/// </summary>
+internal static class Spinners
+{
+    /// <summary>
+    /// Classic tube spinner.
+    /// </summary>
+    public static readonly ImmutableArray<char> Tube = new[]
+    {
+        '|',
+        '/',
+        '-',
+        '\\',
+        '|',
+        '/',
+        '-',
+        '\\',
+    }.ToImmutableArray();
+
+    /// <summary>
+    /// Arc based spinner.
+    /// </summary>
+    public static readonly ImmutableArray<char> Arc = new[]
+    {
+        '\u25DC',
+        '\u25DD',
+        '\u25DE',
+        '\u25DF',
+    }.ToImmutableArray();
+
+    /// <summary>
+    /// Shuffle Braille based spinner.
+    /// </summary>
+    public static readonly ImmutableArray<char> Shuffle = new[]
+    {
+        '\u2813',
+        '\u2815',
+        '\u2807',
+        '\u2815',
+        '\u281C',
+        '\u281A',
+        '\u2819',
+        '\u280B',
+    }.ToImmutableArray();
+
+    /// <summary>
+    /// Snake Braille based spinner.
+    /// </summary>
+    public static readonly ImmutableArray<char> Snake = new[]
+    {
+        '\u2847',
+        '\u28C6',
+        '\u28E4',
+        '\u28F0',
+        '\u28B8',
+        '\u2839',
+        '\u281B',
+        '\u280F',
+    }.ToImmutableArray();
+
+    /// <summary>
+    /// Block corners spinner.
+    /// </summary>
+    public static readonly ImmutableArray<char> Corners = new[]
+    {
+        '\u2599',
+        '\u259B',
+        '\u259C',
+        '\u259F',
+    }.ToImmutableArray();
+
+    /// <summary>
+    /// Circle spinner.
+    /// </summary>
+    public static readonly ImmutableArray<char> Circle = new[]
+    {
+        '\u25F4',
+        '\u25F7',
+        '\u25F6',
+        '\u25F5',
+    }.ToImmutableArray();
+
+    /// <summary>
+    /// Return spinner for given <paramref name="type"/>.
+    /// </summary>
+    /// <param name="type">Type of the spinner.</param>
+    /// <returns>Spinner characters..</returns>
+    /// <exception cref="NotSupportedException">Thrown in case of bug.</exception>
+    public static ImmutableArray<char> GetSpinner(
+            SpinnerType type)
+    {
+        return type switch
+        {
+            SpinnerType.ASCII => Tube,
+            SpinnerType.Graphic => Arc,
+            SpinnerType.Circle => Circle,
+            SpinnerType.Corners => Corners,
+            SpinnerType.Shuffle => Shuffle,
+            SpinnerType.Snake => Snake,
+            _ => throw new NotSupportedException($"BUG: spiner {type} is unknown."),
+        };
+    }
+}

--- a/src/Radicle.CLI/src/REPL/Generic/IREPLEvaluator.cs
+++ b/src/Radicle.CLI/src/REPL/Generic/IREPLEvaluator.cs
@@ -1,0 +1,38 @@
+namespace Radicle.CLI.REPL.Generic;
+
+using System;
+using System.Threading;
+using Radicle.CLI.Models;
+
+/// <summary>
+/// Interface of the REPL evaluation service.
+/// </summary>
+/// <typeparam name="T">Type of the raw output payload.</typeparam>
+public interface IREPLEvaluator<T> : IREPLEvaluator
+    where T : notnull
+{
+    /// <summary>
+    /// Evaluate given <paramref name="input"/> and produce promise
+    /// of the output.
+    /// </summary>
+    /// <param name="input">Raw user input to process.</param>
+    /// <param name="cancellationToken">Optional cancelation token.</param>
+    /// <returns>Instance of <see cref="EvaluationRawOutputPromise{T}"/>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    /// <exception cref="OperationCanceledException">Thrown
+    ///     if operation is canceled with <paramref name="cancellationToken"/>.</exception>
+    EvaluationRawOutputPromise<T> EvaluateToRawOutput(
+            string input,
+            CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Map given <paramref name="payload"/> to
+    /// <see cref="EvaluationOutput"/>.
+    /// </summary>
+    /// <param name="payload">Raw execution output payload.</param>
+    /// <returns>Instance of <see cref="EvaluationOutput"/>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    EvaluationOutput Map(T payload);
+}

--- a/src/Radicle.CLI/src/REPL/IREPLEvaluator.cs
+++ b/src/Radicle.CLI/src/REPL/IREPLEvaluator.cs
@@ -1,0 +1,45 @@
+﻿namespace Radicle.CLI.REPL;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Radicle.CLI.Models;
+
+/// <summary>
+/// Interface of the REPL evaluation service.
+/// </summary>
+public interface IREPLEvaluator
+{
+    /// <summary>
+    /// Evaluate given <paramref name="input"/> and produce promise
+    /// of the output.
+    /// </summary>
+    /// <param name="input">Raw user input to process.</param>
+    /// <param name="cancellationToken">Optional cancelation token.</param>
+    /// <returns>Instance of <see cref="EvaluationOutputPromise"/>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    /// <exception cref="OperationCanceledException">Thrown
+    ///     if operation is canceled with <paramref name="cancellationToken"/>.</exception>
+    EvaluationOutputPromise Evaluate(
+            string input,
+            CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Perform auditing of the previous evaluation,
+    /// e.g. push <paramref name="input"/> to history etc.
+    /// </summary>
+    /// <param name="input">Evaluated user input.</param>
+    /// <param name="elapsed">Elapsed time from start till end
+    ///     of the <paramref name="input"/> evaluation.</param>
+    /// <param name="cancellationToken">Optional cancelation token.</param>
+    /// <returns>Awaitable task.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    /// <exception cref="OperationCanceledException">Thrown
+    ///     if operation is canceled with <paramref name="cancellationToken"/>.</exception>
+    Task AuditEvaluation(
+            string input,
+            TimeSpan elapsed,
+            CancellationToken cancellationToken = default);
+}

--- a/src/Radicle.CLI/src/REPL/IREPLInputHistory.cs
+++ b/src/Radicle.CLI/src/REPL/IREPLInputHistory.cs
@@ -1,0 +1,94 @@
+﻿namespace Radicle.CLI.REPL;
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+/// <summary>
+/// History component REPL reader/writer.
+/// </summary>
+public interface IREPLInputHistory : IEnumerable<REPLInputHistoryRecord>
+{
+    /// <summary>
+    /// Push given <paramref name="input"/>
+    /// into history. Note that this input may be ignored
+    /// if this instance is configured so. The push also resets
+    /// the current peek window.
+    /// </summary>
+    /// <param name="input">Input to push to history.</param>
+    /// <returns><see langword="true"/> if <paramref name="input"/>
+    ///     was pushed to history stack; <see langword="false"/>
+    ///     otherwise (se details of implementation).</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    public bool Push(string input);
+
+    /*
+    How peek window works, changes the history and works with push:
+
+    history stack:
+
+        a                      \   (oldest)
+        b                       }- history stack (may be empty)
+        c                      /   (newest)
+        [<current live input empty placeholder>] -->  window
+
+     move up will change stack to:
+
+        a
+        b
+        [c]                    --> window
+        <current live value>
+
+     consecutive move down with current value "ca" will change stack to
+     (note the value will not change from "c" to "ca" if instead
+     of move down just push was made):
+
+        a
+        b
+        ca
+        [<current live value>] --> window
+
+     consecutive move up by 2 will change stack to:
+
+        a
+        [b]                    --> window
+        ca
+        <current live value>
+
+     consecutive push of "b" will change stack to
+     (note the peek window is reset as well <current live value>):
+
+        a
+        b
+        ca
+        b
+        [<current live input empty placeholder>] --> window
+     */
+
+    /// <summary>
+    /// Moves peek window upwards returns the value.
+    /// </summary>
+    /// <param name="currentValue">Current value to push.</param>
+    /// <param name="value">Value under the peek window.</param>
+    /// <returns><see langword="true"/> if moved successfully;
+    ///     <see langword="false"/> if there is no value up (in history).</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    bool TryMovePeekWindowUp(
+            string currentValue,
+            [NotNullWhen(returnValue: true)] out string? value);
+
+    /// <summary>
+    /// Moves downwards in the history and returns the value.
+    /// </summary>
+    /// <param name="currentValue">Current value to push.</param>
+    /// <param name="value">Value under the peek window.</param>
+    /// <returns><see langword="true"/> if moved successfully;
+    ///     <see langword="false"/> if there is no value down.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    bool TryMovePeekWindowDown(
+            string currentValue,
+            [NotNullWhen(returnValue: true)] out string? value);
+}

--- a/src/Radicle.CLI/src/REPL/IREPLPrinter.cs
+++ b/src/Radicle.CLI/src/REPL/IREPLPrinter.cs
@@ -1,0 +1,70 @@
+﻿namespace Radicle.CLI.REPL;
+
+using System;
+using Radicle.CLI.Models;
+
+/// <summary>
+/// REPL view models printer.
+/// </summary>
+internal interface IREPLPrinter
+{
+    /// <summary>
+    /// Print given model.
+    /// </summary>
+    /// <param name="model">Last pronted model.</param>
+    /// <param name="request">Request counter for spinner.</param>
+    /// <param name="color">Optionaly enable colors.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameters are missing.</exception>
+    void Print(
+            ProgressViewModel model,
+            ulong request = 0,
+            bool color = false);
+
+    /// <summary>
+    /// Print given model.
+    /// </summary>
+    /// <param name="model">Last pronted model.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameters are missing.</exception>
+    void Clear(
+            ProgressViewModel model);
+
+    /// <summary>
+    /// Print given model.
+    /// </summary>
+    /// <param name="lastModel">Last pronted model.</param>
+    /// <param name="currentModel">Model to print.</param>
+    /// <param name="request">Request counter for spinner.</param>
+    /// <param name="color">Optionaly enable colors.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameters are missing.</exception>
+    void Print(
+            ProgressViewModel lastModel,
+            ProgressViewModel currentModel,
+            ulong request = 0,
+            bool color = false);
+
+    /// <summary>
+    /// Print given model.
+    /// </summary>
+    /// <param name="model">Model to print.</param>
+    /// <param name="color">Optionaly enable colors.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameters are missing.</exception>
+    void Print(PromptViewModel model, bool color = false);
+
+    /// <summary>
+    /// Print given model if the <paramref name="lastModel"/>
+    /// was printed before.
+    /// </summary>
+    /// <param name="lastModel">Last printed model.</param>
+    /// <param name="currentModel">Model to print.</param>
+    /// <param name="color">Optionaly enable colors.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameters are missing.</exception>
+    void Print(
+            PromptViewModel lastModel,
+            PromptViewModel currentModel,
+            bool color = false);
+}

--- a/src/Radicle.CLI/src/REPL/IREPLReaderWriter.cs
+++ b/src/Radicle.CLI/src/REPL/IREPLReaderWriter.cs
@@ -1,0 +1,87 @@
+﻿namespace Radicle.CLI.REPL;
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Radicle.CLI.Models;
+using Radicle.Common;
+
+/// <summary>
+/// REPL (Read Eval Print Loop) console witer.
+/// </summary>
+public interface IREPLReaderWriter
+{
+    /// <summary>
+    /// Write given <paramref name="value"/>
+    /// to user output.
+    /// </summary>
+    /// <param name="value">Value to write if any.</param>
+    /// <returns>Awaitable task.</returns>
+    Task WriteAsync(OutputLine? value = null);
+
+    /// <summary>
+    /// Write given lines <paramref name="values"/>
+    /// to user output.
+    /// </summary>
+    /// <param name="values">Collection of line values to write
+    ///     if any.</param>
+    /// <returns>Awaitable task.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if
+    ///     required parameter is <see langword="null"/>.</exception>
+    Task WriteLinesAsync(IEnumerable<OutputLine> values);
+
+    /// <summary>
+    /// Write given output lines <paramref name="outputFactory"/>
+    /// to user output while providing progress while awaiting
+    /// the output.
+    /// </summary>
+    /// <param name="progress">Progress to use while waiting for
+    ///     <paramref name="outputFactory"/>.</param>
+    /// <param name="outputFactory">Collection of line values to write
+    ///     if any.</param>
+    /// <returns>Awaitable task.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if
+    ///     required parameter is <see langword="null"/>.</exception>
+    Task WriteLinesAsync(
+            TransparentProgress<long> progress,
+            Func<Task<IEnumerable<OutputLine>>> outputFactory);
+
+    /// <summary>
+    /// Writes output separator between repeating
+    /// evaluation outputs.
+    /// </summary>
+    /// <param name="repeat">Number of repeat, starting with 1.</param>
+    /// <param name="total">Total number of repeats.</param>
+    /// <param name="repeatingUserInput">User input which is being evaluated repeatedly,
+    ///     this is usually output of <see cref="ReadAsync(CancellationToken)"/>
+    ///     stripped of markings for repeat.</param>
+    /// <returns>Awaitable task.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if
+    ///     required parameter is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown
+    ///     if <paramref name="repeat"/> or <paramref name="total"/>
+    ///     anre zero of <paramref name="total"/> is smaller than <paramref name="repeat"/>.</exception>
+    Task WriteRepeatEvaluationOutputSeparatorAsync(
+            ushort repeat,
+            ushort total,
+            string repeatingUserInput);
+
+    /// <summary>
+    /// Writes elapsed time mark.
+    /// </summary>
+    /// <param name="elapsed">Amount of elapsed time.</param>
+    /// <returns>Awaitable task.</returns>
+    Task WriteElapsedMarkAsync(TimeSpan elapsed);
+
+    /// <summary>
+    /// Read the user input.
+    /// </summary>
+    /// <param name="cancellationToken">Optional cancellation
+    ///     token to cancel read operation.</param>
+    /// <returns>Input read from the console.</returns>
+    /// <exception cref="OperationCanceledException">Thrown
+    ///     if <paramref name="cancellationToken"/>
+    ///     was cancelled.</exception>
+    Task<string> ReadAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Radicle.CLI/src/REPL/IREPLStylingProvider.cs
+++ b/src/Radicle.CLI/src/REPL/IREPLStylingProvider.cs
@@ -1,0 +1,70 @@
+﻿namespace Radicle.CLI.REPL;
+
+using System;
+using System.Collections.Generic;
+using Radicle.CLI.Models;
+
+/// <summary>
+/// Provider of the styling meta-data for REPL reader and writer.
+/// </summary>
+/// <remarks>This meta data is read by the reader/writer whenever
+/// there is a change in UI. So it is best to provide up to date
+/// information whenever values are requested.</remarks>
+public interface IREPLStylingProvider
+{
+    /// <summary>
+    /// Gets the prompt string one (prefix) of the input line which is displayed
+    /// before the te user accessible input. Think of PS1
+    /// (Prompt String One) from bash
+    /// https://wiki.archlinux.org/title/Bash/Prompt_customization ,
+    /// https://www.gnu.org/savannah-checkouts/gnu/bash/manual/bash.html .
+    /// </summary>
+    string PromptStringOne { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether to use any color in the UI
+    /// if this is supported.
+    /// </summary>
+    bool EnableColor { get; }
+
+    /// <summary>
+    /// Gets preferred type of spinner.
+    /// </summary>
+    SpinnerType SpinnerType { get; }
+
+    /// <summary>
+    /// Gets preferred type of progress bars.
+    /// </summary>
+    ProgressBarsType ProgressBarsType { get; }
+
+    /// <summary>
+    /// Return suggestion tail of the given user <paramref name="input"/>.
+    /// E.g. for input 'foo' return ' bar ...' to be displayed as:
+    /// 'foo bar ...'. This is displayed interactivelly as assisting
+    /// visual only suggestion and it is displayed in different style
+    /// to diferentiate from user written input.
+    /// </summary>
+    /// <param name="input">Input to complete.</param>
+    /// <returns>Completion tail of the <paramref name="input"/>
+    ///     or empty string. Do not return <see langword="null"/>
+    ///     return empty string to avoid completion.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    string GetSuggestionTail(string input);
+
+    /// <summary>
+    /// Returns collection of auto-complete replacements
+    /// of given <paramref name="input"/> which can replace
+    /// entire user input on if user actively selects them.
+    /// For xample think of [tab] completion in shells.
+    /// E.g. for 'f' return 'foo', 'faa' etc.,
+    /// the original <paramref name="input"/>
+    /// MUST NOT not be included, e.g. 'f'.
+    /// </summary>
+    /// <param name="input">Input to find auto-complete
+    ///     replacement for.</param>
+    /// <returns>Collection of auto-completion replacements.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    IEnumerable<string> GetAutocomplete(string input);
+}

--- a/src/Radicle.CLI/src/REPL/REPLConsolePrinter.cs
+++ b/src/Radicle.CLI/src/REPL/REPLConsolePrinter.cs
@@ -1,0 +1,229 @@
+namespace Radicle.CLI.REPL;
+
+using System;
+using System.Linq;
+using Radicle.CLI.Models;
+using Radicle.Common.Check;
+
+/// <summary>
+/// System Console implementation of <see cref="IREPLPrinter"/>.
+/// </summary>
+internal class REPLConsolePrinter : IREPLPrinter
+{
+    /// <inheritdoc/>
+    public void Print(
+            ProgressViewModel model,
+            ulong request = 0,
+            bool color = false)
+    {
+        int bufferWidth = Console.BufferWidth;
+        (int currentLeft, int currentTop) = Console.GetCursorPosition();
+
+        if (currentLeft != 0)
+        {
+            currentLeft = 0;
+        }
+
+        Console.SetCursorPosition(currentLeft, currentTop);
+
+        string progressString = Ensure.Param(model).Value.ToString(request);
+
+        if (progressString.Length >= bufferWidth)
+        {
+            progressString = progressString[..(bufferWidth - 1)];
+        }
+
+        Console.Write(progressString);
+
+        Console.SetCursorPosition(currentLeft, currentTop);
+    }
+
+    /// <inheritdoc/>
+    public void Clear(
+            ProgressViewModel model)
+    {
+        Ensure.Param(model).Done();
+
+        int bufferWidth = Console.BufferWidth;
+        (int currentLeft, int currentTop) = Console.GetCursorPosition();
+
+        if (currentLeft != 0)
+        {
+            currentLeft = 0;
+        }
+
+        Console.SetCursorPosition(currentLeft, currentTop);
+
+        Console.Write(new string(' ', bufferWidth - 1));
+
+        Console.SetCursorPosition(currentLeft, currentTop);
+    }
+
+    /// <inheritdoc/>
+    public void Print(
+            ProgressViewModel lastModel,
+            ProgressViewModel currentModel,
+            ulong request = 0,
+            bool color = false)
+    {
+        Ensure.Param(lastModel).Done();
+        Ensure.Param(currentModel).Done();
+
+        if (ReferenceEquals(lastModel, currentModel))
+        {
+            return; // identity, nothing to do
+        }
+
+        this.Clear(lastModel);
+        this.Print(currentModel, request, color: color);
+    }
+
+    /// <inheritdoc/>
+    public void Print(
+            PromptViewModel model,
+            bool color = false)
+    {
+        Ensure.Param(model).Done();
+
+        int bufferWidth = Console.BufferWidth;
+        int bufferHeight = Console.BufferHeight;
+
+        (int currentLeft, int currentTop) = Console.GetCursorPosition();
+
+        if (currentLeft != 0)
+        {
+            currentLeft = 0;
+        }
+
+        Console.SetCursorPosition(currentLeft, currentTop);
+
+        if (color)
+        {
+            Console.ForegroundColor = ConsoleColor.DarkYellow;
+        }
+
+        Console.Write(model.PromptStringOne.ToArray());
+
+        if (color)
+        {
+            Console.ResetColor();
+        }
+
+        Console.Write(model.UserInputValue);
+
+        if (color)
+        {
+            Console.ForegroundColor = ConsoleColor.DarkGray;
+        }
+
+        Console.Write(model.SuggestionTail.ToArray());
+
+        if (color)
+        {
+            Console.ResetColor();
+        }
+
+        (int left, int top, _) = model.GetCursorPosition(bufferWidth);
+
+        int originLeft = currentLeft + left;
+        int originTop = currentTop + top;
+
+        if (originLeft < 0)
+        {
+            originLeft = 0;
+        }
+        else if (originLeft > bufferWidth)
+        {
+            originLeft = bufferWidth;
+        }
+
+        if (originTop < 0)
+        {
+            originTop = 0;
+        }
+        else if (originTop > bufferHeight)
+        {
+            originTop = bufferHeight;
+        }
+
+        Console.SetCursorPosition(originLeft, originTop);
+    }
+
+    /// <inheritdoc/>
+    public void Print(
+            PromptViewModel lastModel,
+            PromptViewModel currentModel,
+            bool color = false)
+    {
+        Ensure.Param(lastModel).Done();
+        Ensure.Param(currentModel).Done();
+
+        if (ReferenceEquals(lastModel, currentModel))
+        {
+            return; // identity
+        }
+
+        Clear(lastModel);
+
+        this.Print(currentModel, color: color);
+    }
+
+    private static void Clear(PromptViewModel model)
+    {
+        int bufferWidth = Console.BufferWidth;
+        int bufferHeight = Console.BufferHeight;
+        int printOutLength = model.TotalLength;
+        (int currentLeft, int currentTop) = Console.GetCursorPosition();
+
+        (int left, int top, _) = model.GetCursorPosition(bufferWidth);
+        (_, _, int totalLines) = model.GetPrintOutPosition(bufferWidth);
+        int originLeft = currentLeft - left;
+        int originTop = currentTop - top;
+
+        if (originLeft < 0)
+        {
+            originLeft = 0;
+        }
+        else if (originLeft > bufferWidth)
+        {
+            originLeft = bufferWidth;
+        }
+
+        if (originTop < 0)
+        {
+            originTop = 0;
+        }
+        else if (originTop > bufferHeight)
+        {
+            originTop = bufferHeight;
+        }
+
+        // start from the beggining of the block
+        Console.SetCursorPosition(originLeft, originTop);
+
+        for (int i = 0; i < totalLines; i++)
+        {
+            if ((i + 1) == totalLines)
+            {
+                if (printOutLength != 0)
+                {
+                    if (printOutLength % bufferWidth == 0)
+                    {
+                        Console.Write(new string(' ', bufferWidth));
+                    }
+                    else
+                    {
+                        Console.Write(new string(' ', printOutLength % bufferWidth));
+                    }
+                }
+            }
+            else
+            {
+                Console.Write(new string(' ', bufferWidth));
+            }
+        }
+
+        // reset to original position
+        Console.SetCursorPosition(originLeft, originTop);
+    }
+}

--- a/src/Radicle.CLI/src/REPL/REPLConsoleReaderWriter.cs
+++ b/src/Radicle.CLI/src/REPL/REPLConsoleReaderWriter.cs
@@ -1,0 +1,335 @@
+namespace Radicle.CLI.REPL;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Radicle.CLI.Models;
+using Radicle.Common;
+using Radicle.Common.Check;
+using Radicle.Common.Extensions;
+
+/// <summary>
+/// System Console implementation of <see cref="IREPLReaderWriter"/>.
+/// This implementation is not thread safe.
+/// </summary>
+public class REPLConsoleReaderWriter : IREPLReaderWriter
+{
+    private readonly IREPLStylingProvider stylingProvider;
+
+    private readonly IREPLPrinter printer = new REPLConsolePrinter();
+
+    private readonly IREPLInputHistory history;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="REPLConsoleReaderWriter"/> class.
+    /// </summary>
+    /// <param name="stylingProvider">Meta data provider.</param>
+    /// <param name="history">History. Note this is used only to read,
+    ///     the caller is responsible for pushing new records to history.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    public REPLConsoleReaderWriter(
+            IREPLStylingProvider stylingProvider,
+            IREPLInputHistory history)
+    {
+        this.stylingProvider = Ensure.Param(stylingProvider).Value;
+        this.history = Ensure.Param(history).Value;
+    }
+
+    /// <inheritdoc/>
+    public Task WriteAsync(OutputLine? value = null)
+    {
+        if (value is not null)
+        {
+            WriteLine(value, color: !this.stylingProvider.EnableColor);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public Task WriteLinesAsync(IEnumerable<OutputLine> values)
+    {
+        Ensure.Param(values).Done();
+
+        foreach (OutputLine value in values)
+        {
+            Ensure.Param(value).Done();
+
+            WriteLine(value, color: !this.stylingProvider.EnableColor);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public async Task WriteLinesAsync(
+            TransparentProgress<long> progress,
+            Func<Task<IEnumerable<OutputLine>>> outputFactory)
+    {
+        Task<IEnumerable<OutputLine>> task = Ensure.Param(outputFactory).Value();
+        DateTime lastPrintout = DateTime.UtcNow;
+        ProgressViewModel? lastProgress = default;
+        ulong request = 0;
+
+        while (!task.IsCompleted)
+        {
+            if (lastPrintout.IsOlderThan(TimeSpan.FromMilliseconds(250)))
+            {
+                ProgressViewModel currentProgress = new(
+                        progress,
+                        spinner: Spinners.GetSpinner(this.stylingProvider.SpinnerType),
+                        progressBars: ProgressBars.GetBars(this.stylingProvider.ProgressBarsType));
+
+                if (lastProgress is null)
+                {
+                    this.printer.Print(
+                            currentProgress,
+                            request++,
+                            color: this.stylingProvider.EnableColor);
+                }
+                else
+                {
+                    this.printer.Print(
+                            lastProgress,
+                            currentProgress,
+                            request++,
+                            color: this.stylingProvider.EnableColor);
+                }
+
+                lastProgress = currentProgress;
+                lastPrintout = DateTime.UtcNow;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false);
+        }
+
+        if (lastProgress is not null)
+        {
+            this.printer.Clear(lastProgress);
+        }
+
+        IEnumerable<OutputLine> lines = await task.ConfigureAwait(false);
+
+        await this.WriteLinesAsync(lines).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public async Task WriteRepeatEvaluationOutputSeparatorAsync(
+            ushort repeat,
+            ushort total,
+            string repeatingUserInput)
+    {
+        Ensure.Param(repeat).StrictlyPositive().Done();
+        Ensure.Param(total).StrictlyPositive().LowerThanOrEqual(repeat).Done();
+
+        await this.WriteAsync(new OutputLine(new[]
+        {
+            new OutputSnippet(OutputStyle.Emphasized, $"[  {repeat}/{total}  ]> "),
+            new OutputSnippet(OutputStyle.Normal, Ensure.Param(repeatingUserInput).Value),
+        })).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public async Task WriteElapsedMarkAsync(TimeSpan elapsed)
+    {
+        await this.WriteAsync(new OutputLine(new[]
+        {
+            new OutputSnippet(OutputStyle.Emphasized, $"[  elapsed: {elapsed.ToHuman()}  ]"),
+        })).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public Task<string> ReadAsync(
+            CancellationToken cancellationToken = default)
+    {
+        PromptViewModel cleanModel = new(this.stylingProvider.PromptStringOne);
+        PromptViewModel lastModel = cleanModel;
+        LoopCollection<PromptViewModel>? rotatingAutocompleteModels = null;
+        PromptViewModel currentModel = lastModel;
+
+        ConsoleKeyInfo keyInfo;
+
+        this.printer.Print(currentModel, color: this.stylingProvider.EnableColor);
+
+        do
+        {
+            keyInfo = Console.ReadKey(true);
+            bool done = false;
+
+            if (
+                    (keyInfo.Modifiers & ConsoleModifiers.Alt) == ConsoleModifiers.Alt
+                    || (keyInfo.Modifiers & ConsoleModifiers.Control) == ConsoleModifiers.Control)
+            {
+                // Ignore Alt or Ctrl combinations for now
+                continue;
+            }
+            else if (keyInfo.Key == ConsoleKey.Tab)
+            {
+                if (rotatingAutocompleteModels is not null)
+                {
+                    currentModel = rotatingAutocompleteModels.Next();
+                }
+                else
+                {
+                    // Ignore tab key.
+                    string[] replacements = this.stylingProvider
+                            .GetAutocomplete(currentModel.UserInputValue)
+                            .ToArray();
+
+                    if (replacements.Length > 0)
+                    {
+                        rotatingAutocompleteModels = new LoopCollection<PromptViewModel>(
+                                new[] { currentModel }
+                                    .Concat(replacements.Select(s => cleanModel.Write(s))));
+                        currentModel = rotatingAutocompleteModels.Next();
+                    }
+                    else
+                    {
+                        continue;
+                    }
+                }
+            }
+            else if (keyInfo.Key == ConsoleKey.Enter)
+            {
+                rotatingAutocompleteModels = null;
+                done = true;
+            }
+            else if (keyInfo.Key == ConsoleKey.LeftArrow)
+            {
+                currentModel = currentModel.MoveCursorLeft();
+            }
+            else if (keyInfo.Key == ConsoleKey.RightArrow)
+            {
+                currentModel = currentModel.MoveCursorRight();
+            }
+            else if (keyInfo.Key == ConsoleKey.UpArrow)
+            {
+                if (this.history.TryMovePeekWindowUp(currentModel.UserInputValue, out string? windowValue))
+                {
+                    currentModel = cleanModel.Write(windowValue);
+                }
+            }
+            else if (keyInfo.Key == ConsoleKey.DownArrow)
+            {
+                if (this.history.TryMovePeekWindowDown(currentModel.UserInputValue, out string? windowValue))
+                {
+                    currentModel = cleanModel.Write(windowValue);
+                }
+            }
+            else if (keyInfo.Key == ConsoleKey.Backspace)
+            {
+                rotatingAutocompleteModels = null;
+                currentModel = currentModel.BackDelete();
+            }
+            else if (keyInfo.Key == ConsoleKey.Delete)
+            {
+                rotatingAutocompleteModels = null;
+                currentModel = currentModel.ForwardDelete();
+            }
+            else if (keyInfo.KeyChar == '\u0000' || keyInfo.Key == ConsoleKey.Escape)
+            {
+                // Ignore if KeyChar value is \u0000 - special character for non printable keys
+                // or escape
+                continue;
+            }
+            else
+            {
+                rotatingAutocompleteModels = null;
+
+                // add character
+                currentModel = currentModel.Write(keyInfo.KeyChar);
+            }
+
+            // Check completion
+            int bufferWidth = Console.BufferWidth;
+
+            if (!done && ReferenceEquals(lastModel, currentModel))
+            {
+                // pass, keep current model completion intact
+            }
+            else if (
+                    !done
+                    && currentModel.TillTailLength < bufferWidth)
+            {
+                string suggestion = this.stylingProvider.GetSuggestionTail(
+                        currentModel.UserInputValue);
+
+                if (suggestion.Length > 0
+                        && (currentModel.TillTailLength + suggestion.Length) < bufferWidth)
+                {
+                    currentModel = currentModel.WithSuggestionTail(suggestion);
+                }
+                else
+                {
+                    currentModel = currentModel.WithSuggestionTail(string.Empty);
+                }
+            }
+            else
+            {
+                currentModel = currentModel.WithSuggestionTail(string.Empty);
+            }
+
+            this.printer.Print(
+                    lastModel,
+                    currentModel,
+                    color: this.stylingProvider.EnableColor);
+
+            lastModel = currentModel;
+        }
+        while (keyInfo.Key != ConsoleKey.Enter);
+
+        Console.WriteLine();
+
+        return Task.FromResult(currentModel.UserInputValue);
+    }
+
+    private static void WriteLine(
+            OutputLine line,
+            bool color = false)
+    {
+        bool notFirst = false;
+
+        foreach (OutputSnippet snippet in line)
+        {
+            if (notFirst && line.Separator == OutputSnippetSeparator.Space)
+            {
+                Console.Write(' ');
+            }
+
+            notFirst = true;
+
+            if (color)
+            {
+                switch (snippet.Style)
+                {
+                    case OutputStyle.Bold:
+                        Console.ForegroundColor = ConsoleColor.DarkYellow;
+                        break;
+                    case OutputStyle.Normal:
+                        Console.ResetColor();
+                        break;
+                    case OutputStyle.Emphasized:
+                        Console.ForegroundColor = ConsoleColor.DarkCyan;
+                        break;
+                    case OutputStyle.Comment:
+                        Console.ForegroundColor = ConsoleColor.Green;
+                        break;
+                    default:
+                        throw new NotSupportedException($"BUG: Unknown style {snippet.Style}");
+                }
+            }
+
+            Console.Write(snippet.Value);
+        }
+
+        if (color)
+        {
+            Console.ResetColor();
+        }
+
+        Console.WriteLine();
+    }
+}

--- a/src/Radicle.CLI/src/REPL/REPLEventLoop.cs
+++ b/src/Radicle.CLI/src/REPL/REPLEventLoop.cs
@@ -1,0 +1,156 @@
+namespace Radicle.CLI.REPL;
+
+using System;
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Radicle.CLI.Models;
+using Radicle.Common.Check;
+
+/// <summary>
+/// REPL (Read-eval-print loop) loop is construct actually
+/// listening and evaluating events. Create and call this loop
+/// from your CLI program.
+/// </summary>
+public sealed class REPLEventLoop
+{
+    /// <summary>
+    /// Regular expression matching the integer field name.
+    /// </summary>
+    private static readonly Regex MultiInputRegex = new(
+            "\\A([1-9][0-9]{0,3}\\s+)([^\\s].+)\\z",
+            RegexOptions.Compiled | RegexOptions.Singleline);
+
+    private readonly IREPLReaderWriter readerWriter;
+
+    private readonly IREPLEvaluator evaluator;
+
+    private readonly bool allowMultiInput = true;
+
+    private readonly bool allowRepeats = true;
+
+    private readonly TimeSpan slowThreshold = TimeSpan.FromSeconds(2);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="REPLEventLoop"/> class.
+    /// </summary>
+    /// <param name="readerWriter">REPL reader writer.</param>
+    /// <param name="evaluator">Evaluator of the user input.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    public REPLEventLoop(
+            IREPLReaderWriter readerWriter,
+            IREPLEvaluator evaluator)
+    {
+        this.readerWriter = Ensure.Param(readerWriter).Value;
+        this.evaluator = Ensure.Param(evaluator).Value;
+    }
+
+    /// <summary>
+    /// Decompose given <paramref name="input"/> to multi-input prefix
+    /// and clean input.
+    /// </summary>
+    /// <param name="input">Input to decompose.</param>
+    /// <returns>Decomposed input. Prefix can be empty.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    public (string MultiInputPrefix, string Input) DecomposeInput(string input)
+    {
+        Ensure.Param(input).Done();
+
+        if (this.allowMultiInput)
+        {
+            Match match = MultiInputRegex.Match(input);
+
+            if (match.Success && match.Groups[1].Success && match.Groups[2].Success)
+            {
+                return (match.Groups[1].Value, match.Groups[2].Value);
+            }
+        }
+
+        return (string.Empty, input);
+    }
+
+    /// <summary>
+    /// Runs the loop.
+    /// </summary>
+    /// <param name="cancellationToken">Optional cancelation token
+    ///     used for cancelling loop.</param>
+    /// <exception cref="OperationCanceledException">Thrown
+    ///     if operation is cancelled with <paramref name="cancellationToken"/>.</exception>
+    /// <returns>Awaitable task.</returns>
+    public async Task RunAsync(
+            CancellationToken cancellationToken = default)
+    {
+        while (true)
+        {
+            string input = await this.readerWriter.ReadAsync(cancellationToken).ConfigureAwait(false);
+
+            (ushort repeats, input) = this.ExtractRepeats(input);
+
+            for (ushort i = 0; i < repeats; i++)
+            {
+                if (i > 0)
+                {
+                    await this.readerWriter.WriteRepeatEvaluationOutputSeparatorAsync(
+                            (ushort)(i + 1),
+                            repeats,
+                            input).ConfigureAwait(false);
+                }
+
+                Stopwatch sw = Stopwatch.StartNew();
+                EvaluationOutputPromise outputPromise = this.evaluator.Evaluate(
+                        input,
+                        cancellationToken: cancellationToken);
+                EvaluationOutput? output = default;
+
+                await this.readerWriter.WriteLinesAsync(
+                        outputPromise.Progress,
+                        async () =>
+                        {
+                            output = await outputPromise.Promise
+                                    .ConfigureAwait(false);
+
+                            return output.OutputLines;
+                        }).ConfigureAwait(false);
+
+                sw.Stop();
+
+#pragma warning disable CA1508 // Avoid dead conditional code
+                if (output?.State == EvaluationOutputState.Exit)
+                {
+                    return;
+                }
+                else if (sw.Elapsed > this.slowThreshold)
+                {
+                    await this.readerWriter.WriteElapsedMarkAsync(sw.Elapsed).ConfigureAwait(false);
+                }
+#pragma warning restore CA1508 // Avoid dead conditional code
+
+                await this.evaluator.AuditEvaluation(
+                        input,
+                        sw.Elapsed,
+                        cancellationToken: cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private (ushort Repeats, string Input) ExtractRepeats(string input)
+    {
+        if (this.allowRepeats)
+        {
+            Match match = MultiInputRegex.Match(input);
+
+            if (match.Success
+                    && match.Groups[2].Success
+                    && ushort.TryParse(input.Split(' ', 2)[0], out ushort r)
+                    && r > 1)
+            {
+                return (r, match.Groups[2].Value);
+            }
+        }
+
+        return (1, input);
+    }
+}

--- a/src/Radicle.CLI/src/REPL/REPLInputHistory.cs
+++ b/src/Radicle.CLI/src/REPL/REPLInputHistory.cs
@@ -1,0 +1,261 @@
+namespace Radicle.CLI.REPL;
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Radicle.Common.Check;
+
+/// <summary>
+/// Default implementation of IREPLInputHistory input history stack.
+/// </summary>
+/// <remarks>This class is not thread safe.</remarks>
+public sealed class REPLInputHistory : IREPLInputHistory
+{
+    /// <summary>
+    /// Historical stack.
+    /// </summary>
+    private readonly Stack<REPLInputHistoryRecord> history = new();
+
+    /// <summary>
+    /// Future stack cleaned on any call to <see cref="Push(string)"/>
+    /// used when using peek window, last value is always discarted on push.
+    /// </summary>
+    private readonly Stack<REPLInputHistoryRecord> future = new();
+
+    /// <summary>
+    /// Capacity overhead to avoid too frequent shrinks.
+    /// </summary>
+    private readonly ushort maxCapacityOverhead = 64;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="REPLInputHistory"/> class.
+    /// </summary>
+    /// <param name="maxCapacity">Maximum capacity of the input history.</param>
+    /// <param name="initialRecords">Initial records if any. First record
+    ///     is oldest.</param>
+    /// <param name="ignoreInputsWithPrefix">Prefix to use for ignoring
+    ///     inputs when calling <see cref="Push(string)"/>.
+    ///     Set to <see langword="null"/> to avoid ignoring,
+    ///     defaults to shell commonly used space character.</param>
+    /// <param name="ignoreRepeatedInputs">Flag determining whether to
+    ///     ignore repeating commands when calling <see cref="Push(string)"/>.
+    ///     Set to <see langword="true"/> for shell like behaviour.</param>
+    /// <exception cref="ArgumentNullException">Thrown if
+    ///     <paramref name="initialRecords"/> contains <see langword="null"/>
+    ///     values.</exception>
+    public REPLInputHistory(
+            ushort maxCapacity = 2042,
+            IEnumerable<string>? initialRecords = null,
+            string? ignoreInputsWithPrefix = " ",
+            bool ignoreRepeatedInputs = false)
+    {
+        this.MaxCapacity = maxCapacity;
+        this.IgnoreInputsWithPrefix = ignoreInputsWithPrefix;
+        this.IgnoreRepeatedInputs = ignoreRepeatedInputs;
+
+        foreach (string recString in Ensure.Optional(initialRecords).AllNotNull())
+        {
+            this.history.Push(
+                    new REPLInputHistoryRecord(
+                        recString,
+                        isInitRecord: true));
+        }
+    }
+
+    /// <summary>
+    /// Gets maximum capacity of the history stack exposed to user.
+    /// </summary>
+    public ushort MaxCapacity { get; }
+
+    /// <summary>
+    /// Gets prefix of inputs which will be ignored,
+    /// or <see langword="null"/> if not applicable.
+    /// </summary>
+    public string? IgnoreInputsWithPrefix { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether repeated
+    /// inputs should be ignored.
+    /// </summary>
+    public bool IgnoreRepeatedInputs { get; }
+
+    /// <inheritdoc/>
+    public bool Push(string input)
+    {
+        Ensure.Param(input).Done();
+
+        REPLInputHistoryRecord? lastF = null;
+
+        while (this.future.TryPop(out REPLInputHistoryRecord f))
+        {
+            if (lastF.HasValue)
+            {
+                this.history.Push(lastF.Value);
+            }
+
+            // discard last record which is current input
+            lastF = f;
+        }
+
+        if (this.TryPushToHistory(input))
+        {
+            this.Shrink();
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <inheritdoc/>
+    public bool TryMovePeekWindowUp(
+            string currentValue,
+            [NotNullWhen(returnValue: true)] out string? value)
+    {
+        Ensure.Param(currentValue).Done();
+
+        value = default;
+
+        if (
+                this.future.Count < this.MaxCapacity
+                && this.history.TryPop(out REPLInputHistoryRecord v))
+        {
+            if (this.future.Count == 0)
+            {
+                this.future.Push(new REPLInputHistoryRecord(currentValue));
+            }
+            else if (this.future.TryPeek(out REPLInputHistoryRecord currentWidow)
+                    && currentWidow.Value != currentValue)
+            {
+                _ = this.future.Pop();
+                this.future.Push(new REPLInputHistoryRecord(
+                        currentValue,
+                        isInitRecord: currentWidow.IsInitRecord,
+                        isModified: true));
+            }
+
+            this.future.Push(v);
+
+            value = v.Value;
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <inheritdoc/>
+    public bool TryMovePeekWindowDown(
+            string currentValue,
+            [NotNullWhen(returnValue: true)] out string? value)
+    {
+        Ensure.Param(currentValue).Done();
+
+        value = default;
+
+        if (this.future.Count <= 1)
+        {
+            return false;
+        }
+        else if (this.future.TryPop(out REPLInputHistoryRecord currentWidow))
+        {
+            if (currentWidow.Value != currentValue)
+            {
+                this.history.Push(
+                        new REPLInputHistoryRecord(
+                            currentValue,
+                            isInitRecord: currentWidow.IsInitRecord,
+                            isModified: true));
+            }
+            else
+            {
+                this.history.Push(currentWidow);
+            }
+
+            value = this.future.Peek().Value;
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
+
+    /// <inheritdoc/>
+    public IEnumerator<REPLInputHistoryRecord> GetEnumerator()
+    {
+        return this.history
+                .Take(Math.Max(this.MaxCapacity - (this.future.Count - 1), 0))
+                .Reverse()
+                .Concat(this.future.Take(this.future.Count - 1))
+                .GetEnumerator();
+    }
+
+    /// <inheritdoc/>
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return this.GetEnumerator();
+    }
+
+    /// <summary>
+    /// Push given <paramref name="input"/>
+    /// to history in a clean way, ignoring empty, null,
+    /// skipped or duplicit values.
+    /// </summary>
+    /// <param name="input">Input to push.</param>
+    /// <returns><see langword="true"/> if pushed;
+    ///     <see langword="false"/> otherwise.</returns>
+    private bool TryPushToHistory(string? input)
+    {
+        if (string.IsNullOrEmpty(input))
+        {
+            return false;
+        }
+        else if (this.IgnoreInputsWithPrefix is not null
+                && input.StartsWith(this.IgnoreInputsWithPrefix, StringComparison.Ordinal))
+        {
+            return false;
+        }
+        else if (
+                this.IgnoreRepeatedInputs
+                && this.history.TryPeek(out REPLInputHistoryRecord last)
+                && input.Equals(last.Value, StringComparison.Ordinal))
+        {
+            return false;
+        }
+        else
+        {
+            this.history.Push(new REPLInputHistoryRecord(input));
+
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Shrink currrent history to maximum capacity if needed.
+    /// </summary>
+    private void Shrink()
+    {
+        if (this.history.Count > (this.MaxCapacity + this.maxCapacityOverhead))
+        {
+            Stack<REPLInputHistoryRecord> tmp = new(this.MaxCapacity);
+
+            for (int i = 0; i < this.MaxCapacity; i++)
+            {
+                if (this.history.TryPop(out REPLInputHistoryRecord value))
+                {
+                    tmp.Push(value);
+                }
+            }
+
+            this.history.Clear();
+
+            while (tmp.TryPop(out REPLInputHistoryRecord value))
+            {
+                this.history.Push(value);
+            }
+        }
+    }
+}

--- a/src/Radicle.CLI/src/REPL/REPLInputHistoryRecord.cs
+++ b/src/Radicle.CLI/src/REPL/REPLInputHistoryRecord.cs
@@ -1,0 +1,89 @@
+﻿namespace Radicle.CLI.REPL;
+
+using System;
+using Radicle.Common.Check;
+
+/// <summary>
+/// REPL history record.
+/// </summary>
+public readonly struct REPLInputHistoryRecord : IEquatable<REPLInputHistoryRecord>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="REPLInputHistoryRecord"/> struct.
+    /// </summary>
+    /// <param name="value">Value of the record, can be empty.</param>
+    /// <param name="isInitRecord">Flag determining
+    ///     if the record is from the initial history init.</param>
+    /// <param name="isModified">Flag determining if this record
+    ///     was modified because of peek window value replacement.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    public REPLInputHistoryRecord(
+            string value,
+            bool isInitRecord = false,
+            bool isModified = false)
+    {
+        this.Value = Ensure.Param(value).Value;
+        this.IsInitRecord = isInitRecord;
+        this.IsModified = isModified;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether
+    /// the record is from the initial history init.
+    /// </summary>
+    public bool IsInitRecord { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether this record
+    /// was modified because of peek window value replacement.
+    /// </summary>
+    public bool IsModified { get; }
+
+    /// <summary>
+    /// Gets the string value of the record, can be empty.
+    /// </summary>
+    public string Value { get; } = string.Empty;
+
+    /// <summary>
+    /// Compare records.
+    /// </summary>
+    /// <param name="left">Left operand.</param>
+    /// <param name="right">Right operand.</param>
+    /// <returns><see langword="true"/> if equal.</returns>
+    public static bool operator ==(REPLInputHistoryRecord left, REPLInputHistoryRecord right)
+    {
+        return left.Equals(right);
+    }
+
+    /// <summary>
+    /// Compare records.
+    /// </summary>
+    /// <param name="left">Left operand.</param>
+    /// <param name="right">Right operand.</param>
+    /// <returns><see langword="true"/> if NON equal.</returns>
+    public static bool operator !=(REPLInputHistoryRecord left, REPLInputHistoryRecord right)
+    {
+        return !(left == right);
+    }
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj)
+    {
+        return obj is REPLInputHistoryRecord rec && this.Equals(rec);
+    }
+
+    /// <inheritdoc/>
+    public bool Equals(REPLInputHistoryRecord other)
+    {
+        return this.Value.Equals(other.Value, StringComparison.Ordinal)
+                && this.IsInitRecord == other.IsInitRecord
+                && this.IsModified == other.IsModified;
+    }
+
+    /// <inheritdoc/>
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(this.Value, this.IsInitRecord, this.IsModified);
+    }
+}

--- a/src/Radicle.CLI/src/Radicle.CLI.csproj
+++ b/src/Radicle.CLI/src/Radicle.CLI.csproj
@@ -3,7 +3,7 @@
         <Title>Radicle.CLI</Title>
         <Description>Radicle.CLI library.</Description>
         <Summary>Radicle.CLI library.</Summary>
-        <TargetFramework>netstandard2.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <IsSDK>true</IsSDK>
         <!--PackageIcon>tbd.png</PackageIcon-->
     </PropertyGroup>
@@ -27,9 +27,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="../../Radicle.Common/src/Radicle.Common.csproj">
-            <Private>false</Private>
-        </ProjectReference>
+        <ProjectReference Include="../../Radicle.Alike/src/Radicle.Alike.csproj" />
     </ItemGroup>
 
     <!--
@@ -42,4 +40,5 @@
         <None Include="../../../.editorconfig" Link=".editorconfig" />
         <None Include="../../../stylecop.json" Link="stylecop.json" />
     </ItemGroup>
+
 </Project>

--- a/src/Radicle.Common/src/Check/Models/IStringParam.cs
+++ b/src/Radicle.Common/src/Check/Models/IStringParam.cs
@@ -29,6 +29,14 @@ public interface IStringParam : IParam<string>, IEnumerable<char>
     IStringParam NotWhiteSpace();
 
     /// <summary>
+    /// Checks if the parameter value is contains any new lines.
+    /// </summary>
+    /// <returns>This instance of <see cref="IStringParam"/>.</returns>
+    /// <exception cref="ArgumentException">Thrown when the
+    ///     parameter value contains new lines.</exception>
+    IStringParam NoNewLines();
+
+    /// <summary>
     /// Checks if the parameter value length is inside given range, throws if not.
     /// By default the range is inclusive.
     /// </summary>

--- a/src/Radicle.Common/src/Check/Models/StringParam.cs
+++ b/src/Radicle.Common/src/Check/Models/StringParam.cs
@@ -58,6 +58,21 @@ internal readonly struct StringParam : IStringParam
     }
 
     /// <inheritdoc/>
+    public IStringParam NoNewLines()
+    {
+        if (this.InnerParam.IsSpecified
+                && this.InnerParam.Value.Length != 0
+                && !TypedNameSpec.SingleLine.IsValid(this.InnerParam.Value))
+        {
+            throw new ArgumentException(
+                    $"{this.InnerParam.DescriptionWithValue} cannot be a string with new lines.",
+                    this.InnerParam.Name);
+        }
+
+        return this;
+    }
+
+    /// <inheritdoc/>
     public IStringParam InRange(
             int lowerBound,
             int upperBound,

--- a/src/Radicle.Common/src/Dump.cs
+++ b/src/Radicle.Common/src/Dump.cs
@@ -1,5 +1,9 @@
 ﻿namespace Radicle.Common;
 
+using System;
+using Radicle.Common.Tokenization;
+using Radicle.Common.Tokenization.Models;
+
 /// <summary>
 /// Collection of (text) dump related utilities akin to those in Python.
 /// </summary>
@@ -29,5 +33,65 @@ public static class Dump
         string? up = upperBound?.ToString() ?? "?";
 
         return $"{bra}{low}, {up}{ket}";
+    }
+
+    /// <summary>
+    /// Dump string value as string literal.
+    /// </summary>
+    /// <param name="value">Value to dump.</param>
+    /// <param name="literalDefinition">Definition
+    ///     of the string literal to use,
+    ///     defaults to conservative C like string literal.</param>
+    /// <returns>Encoded string with quotation marks.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    public static string Literal(
+            string value,
+            IStringLiteralDefinition? literalDefinition = null)
+    {
+        IStringLiteralDefinition def = literalDefinition
+                ?? CLikeStringLiteralDefinition.Conservative;
+
+        return def.GetLiteral(value);
+    }
+
+    /// <summary>
+    /// Dump character as string literal.
+    /// </summary>
+    /// <param name="value">Value to dump.</param>
+    /// <param name="literalDefinition">Definition
+    ///     of the string literal to use,
+    ///     defaults to conservative C like string literal.</param>
+    /// <returns>Encoded string with quotation marks.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    public static string Literal(
+            char value,
+            IStringLiteralDefinition? literalDefinition = null)
+    {
+        IStringLiteralDefinition def = literalDefinition
+                ?? CLikeStringLiteralDefinition.Conservative;
+
+        return def.GetLiteral(new string(value, 1));
+    }
+
+    /// <summary>
+    /// Dump value as string literal.
+    /// </summary>
+    /// <param name="value">Value to dump.</param>
+    /// <param name="literalDefinition">Definition
+    ///     of the string literal to use,
+    ///     defaults to conservative C like string literal.</param>
+    /// <returns>Encoded string with quotation marks.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    public static string Literal(
+            TokenWithValue value,
+            IStringLiteralDefinition? literalDefinition = null)
+    {
+        IStringLiteralDefinition def = literalDefinition
+                ?? CLikeStringLiteralDefinition.Conservative;
+
+        return def.GetLiteral(value);
     }
 }

--- a/src/Radicle.Common/src/Extensions/DateTimeExtensions.cs
+++ b/src/Radicle.Common/src/Extensions/DateTimeExtensions.cs
@@ -1,0 +1,53 @@
+namespace Radicle.Common.Extensions;
+
+using System;
+using Radicle.Common.Check;
+
+/// <summary>
+/// Collection of date related extensions.
+/// </summary>
+public static class DateTimeExtensions
+{
+    /// <summary>
+    /// Determines if the given date is older than given
+    /// <paramref name="duration"/> before the current time.
+    /// </summary>
+    /// <param name="date">Date value.</param>
+    /// <param name="duration">Time duration to evaluate the "oldness".</param>
+    /// <returns>Boolean value determining if the
+    ///     <paramref name="date"/> if older than
+    ///     <paramref name="duration"/> before the current time.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if the
+    ///     <paramref name="duration"/> is zero or negative.</exception>
+    public static bool IsOlderThan(
+            this DateTimeOffset date,
+            TimeSpan duration)
+    {
+        TimeSpan interval = DateTimeOffset.UtcNow.Subtract(date);
+
+        return interval > Ensure.Param(duration).StrictlyPositive().Value;
+    }
+
+    /// <summary>
+    /// Determines if the given UTC date is older than given
+    /// <paramref name="duration"/> before the current time.
+    /// </summary>
+    /// <param name="dateTime">Date value.</param>
+    /// <param name="duration">Time duration to evaluate the "oldness".</param>
+    /// <returns>Boolean value determining if the
+    ///     <paramref name="dateTime"/> if older than
+    ///     <paramref name="duration"/> before the current time.</returns>
+    /// <exception cref="ArgumentException">Thrown if the <paramref name="dateTime"/>
+    ///     is not UTC <see cref="DateTime"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if the
+    ///     <paramref name="duration"/> is zero or negative.</exception>
+    public static bool IsOlderThan(
+            this DateTime dateTime,
+            TimeSpan duration)
+    {
+        TimeSpan interval = DateTimeOffset.UtcNow.Subtract(
+                Ensure.Param(dateTime).IsUTC().Value);
+
+        return interval > Ensure.Param(duration).StrictlyPositive().Value;
+    }
+}

--- a/src/Radicle.Common/src/Extensions/EnumerableExtensions.cs
+++ b/src/Radicle.Common/src/Extensions/EnumerableExtensions.cs
@@ -160,11 +160,7 @@ public static class EnumerableExtensions
                     getSizeFromGetter = false;
                 }
 
-                if (currentBucket == null)
-                {
-                    currentBucket = new T[size];
-                }
-
+                currentBucket ??= new T[size];
                 currentBucket[currentBatchSize++] = item;
 
                 if (currentBatchSize == size)

--- a/src/Radicle.Common/src/Extensions/TimeSpanExtensions.cs
+++ b/src/Radicle.Common/src/Extensions/TimeSpanExtensions.cs
@@ -1,0 +1,420 @@
+namespace Radicle.Common.Extensions;
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Radicle.Common.Check;
+
+/// <summary>
+/// Extensions for time durations.
+/// </summary>
+public static class TimeSpanExtensions
+{
+    private const string NanoSecondSI = "ns"; /* GREEK SMALL LETTER MU */
+    private const string MicroSecondSI = "\u03bcs"; /* GREEK SMALL LETTER MU */
+    private const string MilliSecondSI = "ms";
+    private const string SecondSI = "s";
+    private const string MinuteSI = "m";
+    private const string HourSI = "h";
+    private const string DaySI = "d";
+    private const string YearSI = "y";
+    private const string InfinitySI = "\u221E";
+    private const string NegativeInfinitySI = "-\u221E";
+
+    private const string NanoSecond = "nanosecond";
+    private const string MicroSecond = "microsecond";
+    private const string MilliSecond = "millisecond";
+    private const string Second = "second";
+    private const string Minute = "minute";
+    private const string Hour = "hour";
+    private const string Day = "day";
+    private const string Year = "year";
+
+    private const string NanoSeconds = "nanoseconds";
+    private const string MicroSeconds = "microseconds";
+    private const string MilliSeconds = "milliseconds";
+    private const string Seconds = "seconds";
+    private const string Minutes = "minutes";
+    private const string Hours = "hours";
+    private const string Days = "days";
+    private const string Years = "years";
+
+    private const string Infinity = "+\u221E";
+    private const string NegativeInfinity = "-\u221E";
+
+    private const string And = "and";
+
+    private const int YearDuration = 365;
+
+    /// <summary>
+    /// Returns <paramref name="span"/> if it is shorter than
+    /// <paramref name="alternative"/>, otherwise returns <paramref name="alternative"/>.
+    /// </summary>
+    /// <param name="span">Original time span.</param>
+    /// <param name="alternative">Other time span to choose if <paramref name="span"/>
+    ///     is longer than <paramref name="alternative"/>.</param>
+    /// <returns><paramref name="span"/> if shorter
+    ///     or equal than <paramref name="alternative"/>,
+    ///     otherwise <paramref name="alternative"/>.</returns>
+    public static TimeSpan UseIfShorterOr(
+            this TimeSpan span,
+            TimeSpan alternative)
+    {
+        if (span <= alternative)
+        {
+            return span;
+        }
+
+        return alternative;
+    }
+
+    /// <summary>
+    /// Returns <paramref name="span"/> if it is longer than
+    /// <paramref name="alternative"/>, otherwise returns <paramref name="alternative"/>.
+    /// </summary>
+    /// <param name="span">Original time span.</param>
+    /// <param name="alternative">Other time span to choose if <paramref name="span"/>
+    ///     is shorter than <paramref name="alternative"/>.</param>
+    /// <returns><paramref name="span"/> if longer
+    ///     or equal than <paramref name="alternative"/>,
+    ///     otherwise <paramref name="alternative"/>.</returns>
+    public static TimeSpan UseIfLongerOr(
+            this TimeSpan span,
+            TimeSpan alternative)
+    {
+        if (span >= alternative)
+        {
+            return span;
+        }
+
+        return alternative;
+    }
+
+    /// <summary>
+    /// Perform modulo of <see cref="TimeSpan"/> by given time span
+    /// returning division reminder with use of ticks.
+    /// See https://en.wikipedia.org/wiki/Modulo_operation .
+    /// </summary>
+    /// <param name="dividend">Time span to perform modulo on.</param>
+    /// <param name="divisor">Time span to perform modulo with.</param>
+    /// <returns>Modulo of the time span division.</returns>
+    /// <exception cref="DivideByZeroException">Thrown if
+    ///     <paramref name="divisor"/> is of zero length.</exception>
+    public static TimeSpan Mod(
+            this TimeSpan dividend,
+            TimeSpan divisor)
+    {
+        return TimeSpan.FromTicks(dividend.Ticks % divisor.Ticks);
+    }
+
+    /// <summary>
+    /// Return counter, human readable, representation of
+    /// the <see cref="TimeSpan"/> instance. Examples: "[-]00:00:01.00" (h:m:s),
+    /// "[-]1d 01:00:00.00", "[-]1y 1d 01:00:00.00".
+    /// Year is defined as 365 days.
+    /// </summary>
+    /// <param name="span">Time span to represent.</param>
+    /// <param name="secondsFloatingPrecission">Precission of seconds
+    ///     floating part, allowed range is [0, 3].</param>
+    /// <returns>String representation of the <paramref name="span"/>.</returns>
+    /// <exception cref="NotSupportedException">Thrown in case of bug.</exception>
+    public static string ToCounter(
+            this TimeSpan span,
+            byte secondsFloatingPrecission = 2)
+    {
+        string? sign = span.TotalHours < 0 ? "-" : string.Empty;
+        int y = Abs(span.Days / YearDuration);
+        int d = Abs(span.Days % YearDuration);
+        int h = Abs(span.Hours);
+        int m = Abs(span.Minutes);
+        int s = Abs(span.Seconds);
+        string millisecods = string.Empty;
+
+        if (Ensure.Param(secondsFloatingPrecission).InRange(0, 3).Value > 0)
+        {
+            int ms = Abs(RoundToInt32(span.Milliseconds / Math.Pow(10.0, 3 - secondsFloatingPrecission)));
+
+            millisecods = secondsFloatingPrecission switch
+            {
+                1 => $".{ms:D1}",
+                2 => $".{ms:D2}",
+                3 => $".{ms:D3}",
+                _ => throw new NotSupportedException(
+                        $"BUG: {nameof(secondsFloatingPrecission)} {secondsFloatingPrecission} is not supported."),
+            };
+        }
+        else
+        {
+            // round secods
+            s = Abs(RoundToInt32(span.Seconds + (span.Milliseconds / 1000.0)));
+        }
+
+        /*
+         * see (':D2'):
+         * https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings#DFormatString
+         */
+        if (y > 0)
+        {
+            // non zero years
+            return $"{sign}{y}{YearSI} {d}{DaySI} {h:D2}:{m:D2}:{s:D2}{millisecods}";
+        }
+        else if (d > 0)
+        {
+            // non zero days
+            return $"{sign}{d}{DaySI} {h:D2}:{m:D2}:{s:D2}{millisecods}";
+        }
+        else
+        {
+            return $"{sign}{h:D2}:{m:D2}:{s:D2}{millisecods}";
+        }
+    }
+
+    /// <summary>
+    /// Proxy method for <see cref="ToHuman(TimeSpan, bool)"/>
+    /// with brief parameter set to <see langword="true"/>.
+    /// </summary>
+    /// <param name="span">Time span to represent.</param>
+    /// <returns>Short human string representation of <paramref name="span"/>.</returns>
+    public static string ToH(this TimeSpan span)
+    {
+        return span.ToHuman(brief: true);
+    }
+
+    /// <summary>
+    /// Proxy method for <see cref="ToHuman(TimeSpan, bool)"/>
+    /// with brief parameter set to <see langword="true"/>.
+    /// </summary>
+    /// <param name="stopwatch"><see cref="Stopwatch"/> to extract elapsed time from.</param>
+    /// <returns>Short human string representation of <paramref name="stopwatch"/>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    public static string ToH(this Stopwatch stopwatch)
+    {
+        return Ensure.Param(stopwatch).Value.Elapsed.ToHuman(brief: true);
+    }
+
+    /// <summary>
+    /// Return <see cref="TimeSpan"/> instance representation in format
+    /// easily readable for humans (e.g. good for showing estimates).
+    /// Examples: "1 second", "1s" (brief), "4 days", "4d" (brief), etc.
+    /// Year is defined as 365 days. Range is from years to nanosecods.
+    /// </summary>
+    /// <param name="stopwatch"><see cref="Stopwatch"/> to extract elapsed time from.</param>
+    /// <param name="brief">define format of the time units, if set
+    ///     to <see langword="true"/> then the common SI units
+    ///     are used instead of full words.</param>
+    /// <returns>Human string representation of <paramref name="stopwatch"/>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    public static string ToHuman(
+            this Stopwatch stopwatch,
+            bool brief = false)
+    {
+        Ensure.Param(stopwatch).Done();
+
+        return stopwatch.Elapsed.ToHuman(brief: brief);
+    }
+
+    /// <summary>
+    /// Return <see cref="TimeSpan"/> instance representation in format
+    /// easily readable for humans (e.g. good for showing estimates).
+    /// Examples: "1 second", "1s" (brief), "4 days", "4d" (brief), etc.
+    /// Year is defined as 365 days. Range is from years to nanosecods.
+    /// </summary>
+    /// <param name="span">Time span to represent.</param>
+    /// <param name="brief">define format of the time units, if set
+    ///     to <see langword="true"/> then the common SI units
+    ///     are used instead of full words.</param>
+    /// <returns>Human string representation of <paramref name="span"/>.</returns>
+    public static string ToHuman(
+            this TimeSpan span,
+            bool brief = false)
+    {
+        double s = span.TotalSeconds;
+        double m = span.TotalMinutes;
+        double h = span.TotalHours;
+        double d = span.TotalDays;
+        List<string> result = new();
+
+        if (brief)
+        {
+            if (span == TimeSpan.MaxValue)
+            {
+                result.Add(InfinitySI);
+            }
+            else if (span == TimeSpan.MinValue)
+            {
+                result.Add(NegativeInfinitySI);
+            }
+            else if (Abs(s) < 0.000_0016)
+            {
+                result.Add($"{RoundToInt32(span.TotalMilliseconds * 1000_000)}{NanoSecondSI}");
+            }
+            else if (Abs(s) < 0.0016)
+            {
+                result.Add($"{RoundToInt32(span.TotalMilliseconds * 1000)}{MicroSecondSI}");
+            }
+            else if (Abs(s) < 1.6)
+            {
+                result.Add($"{RoundToInt32(span.TotalMilliseconds)}{MilliSecondSI}");
+            }
+            else if (Abs(s) < 60 * 1.6)
+            {
+                result.Add($"{RoundToInt32(s)}{SecondSI}");
+            }
+            else if (Abs(m) < 60 * 1.6)
+            {
+                result.Add($"{RoundToInt32(m)}{MinuteSI}");
+            }
+            else if (Abs(h) < 24 * 1.6)
+            {
+                result.Add($"{RoundToInt32(h)}{HourSI}");
+            }
+            else if (Abs(d) < (YearDuration * 1.6))
+            {
+                result.Add($"{RoundToInt32(d)}{DaySI}");
+            }
+            else
+            {
+                result.Add($"{RoundToInt32(d / YearDuration)}{YearSI}");
+            }
+        }
+        else if (span == TimeSpan.MaxValue)
+        {
+            result.Add(Infinity);
+        }
+        else if (span == TimeSpan.MinValue)
+        {
+            result.Add(NegativeInfinity);
+        }
+        else if (Abs(s) < 0.000_0016)
+        {
+            int t = RoundToInt32(span.TotalMilliseconds * 1000_000);
+
+            result.Add($"{t} {Plural(t, NanoSecond, NanoSeconds)}");
+        }
+        else if (Abs(s) < 0.0016)
+        {
+            int t = RoundToInt32(span.TotalMilliseconds * 1000);
+
+            result.Add($"{t} {Plural(t, MicroSecond, MicroSeconds)}");
+        }
+        else if (Abs(s) < 1.6)
+        {
+            int t = RoundToInt32(span.TotalMilliseconds);
+
+            result.Add($"{t} {Plural(t, MilliSecond, MilliSeconds)}");
+        }
+        else if (Abs(s) < 60 * 1.6)
+        {
+            int t = RoundToInt32(s);
+
+            result.Add($"{t} {Plural(t, Second, Seconds)}");
+        }
+        else if (Abs(m) < 60 * 1.6)
+        {
+            int roundedSeconds = RoundToInt32(s);
+            int tm = roundedSeconds / 60;
+            int ts = Abs(roundedSeconds % 60);
+
+            result.Add($"{tm} {Plural(tm, Minute, Minutes)}");
+
+            if (ts > 0)
+            {
+                result.Add($"{ts} {Plural(ts, Second, Seconds)}");
+            }
+        }
+        else if (Abs(h) < 24 * 1.6)
+        {
+            int roundedMinutes = RoundToInt32(m);
+            int th = roundedMinutes / 60;
+            int tm = roundedMinutes % 60;
+
+            if (Abs(th) > 0)
+            {
+                result.Add($"{th} {Plural(th, Hour, Hours)}");
+                tm = Abs(tm);
+
+                if (tm > 0)
+                {
+                    result.Add($"{tm} {Plural(tm, Minute, Minutes)}");
+                }
+            }
+            else if (Abs(tm) > 0)
+            {
+                result.Add($"{tm} {Plural(tm, Minute, Minutes)}");
+            }
+        }
+        else if (Abs(d) < 7 * 1.6)
+        {
+            int roundedHours = RoundToInt32(h);
+            int td = roundedHours / 24;
+            int th = roundedHours % 24;
+
+            if (Abs(td) > 0)
+            {
+                result.Add($"{td} {Plural(td, Day, Days)}");
+                th = Abs(th);
+
+                if (th > 0)
+                {
+                    result.Add($"{th} {Plural(th, Hour, Hours)}");
+                }
+            }
+            else if (Abs(th) > 0)
+            {
+                result.Add($"{th} {Plural(th, Hour, Hours)}");
+            }
+        }
+        else if (Abs(d) < (YearDuration * 160))
+        {
+            int roundedDays = RoundToInt32(d);
+            int ty = roundedDays / 365;
+            int td = roundedDays % 365;
+
+            if (Abs(ty) > 0)
+            {
+                result.Add($"{ty} {Plural(ty, Year, Years)}");
+                td = Abs(td);
+
+                if (td > 0)
+                {
+                    result.Add($"{td} {Plural(td, Day, Days)}");
+                }
+            }
+            else if (Abs(td) > 0)
+            {
+                result.Add($"{td} {Plural(td, Day, Days)}");
+            }
+        }
+        else
+        {
+            result.Add($"{RoundToInt32(d / YearDuration)} {Years}");
+        }
+
+        return string.Join($" {And} ", result);
+    }
+
+    private static string Plural(
+            int quantity,
+            string singular,
+            string plural)
+    {
+        return Abs(quantity) < 2 ? singular : plural;
+    }
+
+    private static int RoundToInt32(double input)
+    {
+        return (int)Math.Round(input, MidpointRounding.AwayFromZero);
+    }
+
+    private static double Abs(double input)
+    {
+        return Math.Abs(input);
+    }
+
+    private static int Abs(int input)
+    {
+        return Math.Abs(input);
+    }
+}

--- a/src/Radicle.Common/src/IsExternalInit.cs
+++ b/src/Radicle.Common/src/IsExternalInit.cs
@@ -1,0 +1,10 @@
+#pragma warning disable IDE0130 // Namespace does not match folder structure
+namespace System.Runtime.CompilerServices;
+#pragma warning restore IDE0130 // Namespace does not match folder structure
+
+/// <summary>
+/// See https://stackoverflow.com/questions/64749385/predefined-type-system-runtime-compilerservices-isexternalinit-is-not-defined .
+/// </summary>
+internal static class IsExternalInit
+{
+}

--- a/src/Radicle.Common/src/LoopCollection.cs
+++ b/src/Radicle.Common/src/LoopCollection.cs
@@ -1,0 +1,80 @@
+namespace Radicle.Common;
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Radicle.Common.Check;
+
+/// <summary>
+/// Mutable looping collection with looping
+/// wrapping around.
+/// </summary>
+/// <typeparam name="T">Type of the collcetion item.</typeparam>
+public sealed class LoopCollection<T> : IEnumerable<T>
+{
+    private readonly ImmutableArray<T> collection;
+
+    private int cursor;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LoopCollection{T}"/> class.
+    /// </summary>
+    /// <param name="elements">Elements of collection
+    ///     which will be looped over.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown
+    ///     if <paramref name="elements"/> is empty.</exception>
+    public LoopCollection(
+            IEnumerable<T> elements)
+    {
+        this.collection = Ensure.Param(elements)
+                .NotEmpty()
+                .ToImmutableArray();
+    }
+
+    /// <inheritdoc/>
+    public IEnumerator<T> GetEnumerator()
+    {
+        return ((IEnumerable<T>)this.collection).GetEnumerator();
+    }
+
+    /// <inheritdoc/>
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return this.GetEnumerator();
+    }
+
+    /// <summary>
+    /// Advance in position forward and return element on that position.
+    /// </summary>
+    /// <returns>Element on next position.</returns>
+    public T Next()
+    {
+        this.cursor++;
+
+        if (this.cursor >= this.collection.Length)
+        {
+            this.cursor = 0;
+        }
+
+        return this.collection[this.cursor];
+    }
+
+    /// <summary>
+    /// Advance in position backwards and return element on that position.
+    /// </summary>
+    /// <returns>Element on previous position.</returns>
+    public T Prev()
+    {
+        this.cursor--;
+
+        if (this.cursor < 0)
+        {
+            this.cursor = this.collection.Length - 1;
+        }
+
+        return this.collection[this.cursor];
+    }
+}

--- a/src/Radicle.Common/src/Radicle.Common.csproj
+++ b/src/Radicle.Common/src/Radicle.Common.csproj
@@ -37,4 +37,5 @@
         <None Include="../../../.editorconfig" Link=".editorconfig" />
         <None Include="../../../stylecop.json" Link="stylecop.json" />
     </ItemGroup>
+
 </Project>

--- a/src/Radicle.Common/src/Tokenization/Base/StringTokenizer.cs
+++ b/src/Radicle.Common/src/Tokenization/Base/StringTokenizer.cs
@@ -1,0 +1,115 @@
+namespace Radicle.Common.Tokenization.Base;
+
+using System;
+using System.Collections.Generic;
+using Radicle.Common.Check;
+using Radicle.Common.Tokenization.Models;
+
+/// <summary>
+/// Base implementation of <see cref="IStringTokenizer"/>.
+/// </summary>
+/// <remarks>Note binary decoded strings are only parsed
+/// ones, i.e. if the parent <see cref="IStringTokenizer"/> returns
+/// binary decoded string it is not parsed further by this tokenizer.</remarks>
+public abstract class StringTokenizer : IStringTokenizer
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StringTokenizer"/> class.
+    /// </summary>
+    /// <param name="parent">Optional parent tokenizer.</param>
+    internal StringTokenizer(IStringTokenizer? parent = null)
+    {
+        this.Parent = parent;
+    }
+
+    /// <inheritdoc />
+    public IStringTokenizer? Parent { get; }
+
+    /// <inheritdoc/>
+    public IEnumerable<TokenWithValue> Parse(
+            string input,
+            int startAt = 0)
+    {
+        Ensure.Param(input).Done();
+        Ensure.Param(startAt).InRange(0, input.Length).Done();
+
+        IEnumerable<TokenWithValue> parentTokens;
+
+        if (this.Parent is null)
+        {
+            if (startAt == input.Length)
+            {
+                // nothing to parse
+                parentTokens = Array.Empty<TokenWithValue>();
+            }
+            else
+            {
+                parentTokens = new[] { TokenString.GetPassThrough(input, startAt) };
+            }
+        }
+        else
+        {
+            parentTokens = this.Parent.Parse(input, startAt: startAt);
+        }
+
+        foreach (TokenWithValue partialInput in parentTokens)
+        {
+            if (partialInput is TokenString tokenString)
+            {
+                int continueAt = 0;
+
+                while (true)
+                {
+                    TokenMatch decoded = this.TryReadToken(
+                            tokenString,
+                            startAt: continueAt);
+
+                    if (decoded is TokenFailure tokenFailure)
+                    {
+                        throw new FormatException(
+                                $"Input format error at {tokenFailure.RootEndAt}: {tokenFailure.FormatErrorMessage}");
+                    }
+                    else if (decoded is TokenWith token)
+                    {
+                        continueAt = token.ContinueAt;
+
+                        if (token is TokenWithValue tokenWithValue)
+                        {
+                            yield return tokenWithValue;
+                        }
+
+                        if (token.ContinueAt == tokenString.StringValue.Length)
+                        {
+                            break;
+                        }
+                    }
+                }
+            }
+            else
+            {
+                yield return partialInput;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Read the next token starting at <paramref name="startAt"/>.
+    /// </summary>
+    /// <remarks>This method does not take <see cref="Parent"/>
+    /// into consideration.</remarks>
+    /// <param name="input">String bearing input to parse.</param>
+    /// <param name="startAt">Start position for parsing,
+    ///     it is in inclusive range [0, input length].</param>
+    /// <returns><see langword="true"/> if token was read;
+    ///     <see langword="fase"/> if no token is present
+    ///     in <paramref name="input"/> starting at position
+    ///     <paramref name="startAt"/> (e.g. the input was exhausted).</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown
+    ///     if <paramref name="startAt"/> is out of bounds
+    ///     of <paramref name="input"/>.</exception>
+    protected abstract TokenMatch TryReadToken(
+            TokenString input,
+            int startAt = 0);
+}

--- a/src/Radicle.Common/src/Tokenization/CLILikeArgumentsTokenizer.cs
+++ b/src/Radicle.Common/src/Tokenization/CLILikeArgumentsTokenizer.cs
@@ -1,0 +1,172 @@
+namespace Radicle.Common.Tokenization;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Radicle.Common.Check;
+using Radicle.Common.Tokenization.Base;
+using Radicle.Common.Tokenization.Models;
+
+/// <summary>
+/// White-space and escaped string tokenizer like the one used
+/// to parse command line arguments.
+/// </summary>
+public sealed class CLILikeArgumentsTokenizer : StringTokenizer
+{
+    private static readonly HashSet<char> Spaces = new(new[] { ' ', '\t', '\r', '\n', '\f', '\v' });
+
+    private readonly IStringLiteralDefinition stringLiteralDefinition;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CLILikeArgumentsTokenizer"/> class.
+    /// </summary>
+    /// <param name="parent">Optional parent tokenizer.</param>
+    /// <param name="stringLiteralDefinition">Optional string
+    ///     literal definition to use to parse string literals.
+    ///     Defaults to <see cref="CLikeStringLiteralDefinition.Normal"/>
+    ///     with double quotes quoting mark.</param>
+    public CLILikeArgumentsTokenizer(
+            IStringTokenizer? parent = null,
+            IStringLiteralDefinition? stringLiteralDefinition = null)
+            : base(parent)
+    {
+        this.stringLiteralDefinition = stringLiteralDefinition
+                ?? CLikeStringLiteralDefinition.Normal;
+    }
+
+    /// <inheritdoc/>
+    protected override TokenMatch TryReadToken(
+            TokenString input,
+            int startAt = 0)
+    {
+        Ensure.Param(input).Done();
+        Ensure.Param(startAt).InRange(0, input.StringValue.Length).Done();
+
+        string inputString = input.StringValue;
+        bool inToken = false;
+        List<TokenWithValue> buffer = new();
+
+        for (int pos = startAt; pos < inputString.Length; pos++)
+        {
+            char ch = inputString[pos];
+
+            if (Spaces.Contains(ch))
+            {
+                // yield the token so far read till this space character
+                if (inToken)
+                {
+                    break;
+                }
+
+                /* else just skip */
+                continue;
+            }
+
+            inToken = true;
+
+            // try to read string literal
+            TokenDecoding literalDecoding = this.stringLiteralDefinition
+                    .TryReadStringLiteral(input, startAt: pos);
+
+            if (literalDecoding is TokenNoMatch)
+            {
+                buffer.Add(new TokenString(
+                        inputString,
+                        pos,
+                        endAt: pos,
+                        continueAt: pos + 1,
+                        stringValue: new string(ch, 1))
+                {
+                    Parent = input,
+                });
+            }
+            else if (literalDecoding is TokenFailure literalDecodingFailure)
+            {
+                return literalDecodingFailure;
+            }
+            else if (literalDecoding is TokenWithNoValue literalDecodingNoValue)
+            {
+                // advance in position and continue
+                pos = literalDecodingNoValue.EndAt;
+            }
+            else if (literalDecoding is TokenWithValue literalDecodingValue)
+            {
+                // advance in position and continue
+                pos = literalDecodingValue.EndAt;
+                buffer.Add(literalDecodingValue);
+            }
+        }
+
+        if (buffer.Count > 0)
+        {
+            return Merge(buffer);
+        }
+
+        // the input string was exhausted to end
+        return new TokenWithNoValue(
+                inputString,
+                startAt,
+                endAt: Math.Max(startAt, inputString.Length - 1),
+                continueAt: inputString.Length)
+        {
+            Parent = input,
+        };
+    }
+
+    private static TokenWithValue Merge(IReadOnlyList<TokenWithValue> buffer)
+    {
+        Ensure.Collection(buffer).NotEmpty().Done();
+
+        TokenWithValue first = buffer[0];
+        TokenWithValue last = buffer[buffer.Count - 1];
+
+        // binary
+        if (buffer.Any(d => d is TokenBinary))
+        {
+            List<byte> bytes = new();
+
+            foreach (TokenWithValue tokenWithValue in buffer)
+            {
+                if (tokenWithValue is TokenBinary tb)
+                {
+                    bytes.AddRange(tb.Bytes);
+                }
+                else if (tokenWithValue is TokenString ts)
+                {
+                    bytes.AddRange(Encoding.UTF8.GetBytes(ts.StringValue));
+                }
+            }
+
+            return new TokenBinary(
+                    first.SourceString,
+                    first.StartAt,
+                    endAt: last.EndAt,
+                    continueAt: last.ContinueAt,
+                    bytes: bytes)
+            {
+                Parent = first.Parent,
+            };
+        }
+
+        StringBuilder sb = new();
+
+        foreach (TokenWithValue tokenWithValue in buffer)
+        {
+            if (tokenWithValue is TokenString ts)
+            {
+                sb = sb.Append(ts.StringValue);
+            }
+        }
+
+        return new TokenString(
+                first.SourceString,
+                first.StartAt,
+                endAt: last.EndAt,
+                continueAt: last.ContinueAt,
+                stringValue: sb.ToString())
+        {
+            Parent = first.Parent,
+        };
+    }
+}

--- a/src/Radicle.Common/src/Tokenization/CLikeStringLiteralDefinition.cs
+++ b/src/Radicle.Common/src/Tokenization/CLikeStringLiteralDefinition.cs
@@ -1,0 +1,634 @@
+namespace Radicle.Common.Tokenization;
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Radicle.Common.Check;
+using Radicle.Common.Tokenization.Models;
+
+/// <summary>
+/// Implementation of <see cref="IStringLiteralDefinition"/>
+/// which follows escape rules of C: https://en.wikipedia.org/wiki/Escape_sequences_in_C ,
+/// https://redis.io/docs/manual/cli/#string-quoting-and-escaping ,
+/// https://docs.microsoft.com/en-us/cpp/c-language/escape-sequences?view=msvc-170
+/// additional configuration is possible.
+/// </summary>
+public sealed class CLikeStringLiteralDefinition : IStringLiteralDefinition
+{
+    /// <summary>
+    /// Constant of the C like escape character.
+    /// </summary>
+    public const char EscapeMark = '\\';
+
+    /// <summary>
+    /// Constant of the C like double quotation mark.
+    /// </summary>
+    public const char DoubleQuotationMark = '"';
+
+    /// <summary>
+    /// Constant of the C like single quotation mark.
+    /// </summary>
+    public const char SingleQuotationMark = '\'';
+
+    /// <summary>
+    /// Constant of the C like hex prefix in escape sequence.
+    /// </summary>
+    public const char HexPrefix = 'x';
+
+    /// <summary>
+    /// Minimal definition, escaping just quotation (double quotes),
+    /// and escape character itself.
+    /// </summary>
+    public static readonly CLikeStringLiteralDefinition Minimal = new();
+
+    /// <summary>
+    /// Normal definition, escaping common characters
+    /// leaving unicode letters and digits intact.
+    /// </summary>
+    public static readonly CLikeStringLiteralDefinition Normal = new(
+            preferCommonEscapeSequences: true);
+
+    /// <summary>
+    /// Conservative definition, escaping everything
+    /// except common ASCII characters.
+    /// </summary>
+    public static readonly CLikeStringLiteralDefinition Conservative = new(
+            preferCommonEscapeSequences: true,
+            escapeNonAlphanumericAsBinary: true);
+
+    private readonly ParsedTokenStopWord quotationMarkStopWord;
+
+    private readonly ParsedTokenStopWord escapeTokenStopWord;
+
+    private readonly char quotationMarkCharacter;
+
+    private readonly char escapeTokenCharacter;
+
+    private readonly Dictionary<char, char> controlToCommonEscapeCharacters = new()
+    {
+        { 'n', '\n' },
+        { 'r', '\r' },
+        { 't', '\t' },
+        { 'b', '\b' },
+        { 'a', '\a' },
+        { 'f', '\f' },
+        { 'v', '\v' },
+    };
+
+    private readonly Dictionary<char, byte> controlToCommonEscapeCode = new()
+    {
+        { 'n', (byte)'\n' },
+        { 'r', (byte)'\r' },
+        { 't', (byte)'\t' },
+        { 'b', (byte)'\b' },
+        { 'a', (byte)'\a' },
+        { 'f', (byte)'\f' },
+        { 'v', (byte)'\v' },
+    };
+
+    private readonly Dictionary<char, char> commonEscapeCharacters = new()
+    {
+        { '\n', 'n' },
+        { '\r', 'r' },
+        { '\t', 't' },
+        { '\b', 'b' },
+        { '\a', 'a' },
+        { '\f', 'f' },
+        { '\v', 'v' },
+    };
+
+    private readonly Dictionary<byte, char> commonEscapeCodes = new()
+    {
+        { (byte)'\n', 'n' },
+        { (byte)'\r', 'r' },
+        { (byte)'\t', 't' },
+        { (byte)'\b', 'b' },
+        { (byte)'\a', 'a' },
+        { (byte)'\f', 'f' },
+        { (byte)'\v', 'v' },
+    };
+
+    private readonly StopWordStringParser stopWordParser;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CLikeStringLiteralDefinition"/> class.
+    /// </summary>
+    /// <param name="preferCommonEscapeSequences">Value indicating whether
+    ///     common escape sequences are used, like for tab etc.</param>
+    /// <param name="escapeNonAlphanumericAsBinary">Value indicating whether
+    ///     non alpha-numerical (plus common characters) characters
+    ///     are escaped as binary data. Binary tokens have this
+    ///     option implicitly enabled.</param>
+    public CLikeStringLiteralDefinition(
+            bool preferCommonEscapeSequences = false,
+            bool escapeNonAlphanumericAsBinary = false)
+    {
+        this.QuotationMarkStart = new string(DoubleQuotationMark, 1);
+        this.QuotationMarkEnd = this.QuotationMarkStart;
+        this.EscapeTokenStart = new string(EscapeMark, 1);
+        this.EscapeTokenEnd = string.Empty;
+        this.PreferCommonEscapeSequences = preferCommonEscapeSequences;
+        this.EscapeNonAlphanumericAsBinary = escapeNonAlphanumericAsBinary;
+        this.quotationMarkStopWord = DoubleQuotationMark;
+        this.escapeTokenStopWord = EscapeMark;
+        this.quotationMarkCharacter = DoubleQuotationMark;
+        this.escapeTokenCharacter = EscapeMark;
+        this.stopWordParser = this.ConstructStopWordParser();
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether common escape sequences are used,
+    /// like for tab etc.
+    /// </summary>
+    /// <remarks>Complete set of escape sequences:
+    /// '\"', '\'' (depending on <see cref="QuotationMarkStart"/> so it does not clash),
+    /// '\n', '\r', '\t', '\b', '\a', '\\', '\xnn' (hex notation of single byte),
+    /// '\f' (Formfeed Page Break \x0C), '\v' (vertical tab '\x0B'),
+    /// '\?' (not used with this setting).</remarks>
+    public bool PreferCommonEscapeSequences { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether non alphanumerical
+    /// (plus common characters) characters
+    /// are escaped as binary data (in hex notation one byte wide,
+    /// e.g. '\xnn' where n stands for single hex number).
+    /// Binary tokens have this option enabled by default.
+    /// This is to ensure maximal safety of copied token.
+    /// </summary>
+    public bool EscapeNonAlphanumericAsBinary { get; }
+
+    /// <inheritdoc/>
+    public string QuotationMarkStart { get; }
+
+    /// <inheritdoc/>
+    public string QuotationMarkEnd { get; }
+
+    /// <inheritdoc/>
+    public string EscapeTokenStart { get; }
+
+    /// <inheritdoc/>
+    public string EscapeTokenEnd { get; }
+
+    /// <inheritdoc/>
+    public string Encode(TokenWithValue value)
+    {
+        Ensure.Param(value).Done();
+
+        if (value is TokenString ts)
+        {
+            return this.Encode(ts.StringValue);
+        }
+        else if (value is TokenBinary tb)
+        {
+            return this.Encode(tb.Bytes);
+        }
+
+        string type = value?.GetType().ToString() ?? "null";
+
+        throw new NotSupportedException($"BUG: not supported token with value {type}");
+    }
+
+    /// <inheritdoc/>
+    public string GetLiteral(TokenWithValue value)
+    {
+        return new StringBuilder()
+                .Append(this.QuotationMarkStart)
+                .Append(this.Encode(value))
+                .Append(this.QuotationMarkEnd)
+                .ToString();
+    }
+
+    /// <inheritdoc/>
+    public TokenMatch Decode(string input)
+    {
+        return (TokenMatch)this.TryReadStringLiteralInternal(
+                input,
+                startAt: 0,
+                disallowQuotation: true);
+    }
+
+    /// <inheritdoc/>
+    public TokenDecoding TryReadStringLiteral(
+            string input,
+            int startAt = 0)
+    {
+        return this.TryReadStringLiteralInternal(
+                input,
+                startAt: startAt);
+    }
+
+    /// <inheritdoc/>
+    public TokenDecoding TryReadStringLiteral(
+            TokenString input,
+            int startAt = 0)
+    {
+        Ensure.Param(input).Done();
+
+        return this.TryReadStringLiteralInternal(
+                input.StringValue,
+                startAt: startAt,
+                parent: input);
+    }
+
+    private static IEnumerable<string> EncodeToHex(char character)
+    {
+        foreach (byte code in Encoding.UTF8.GetBytes(new[] { character }))
+        {
+#pragma warning disable CA1308 // Normalize strings to uppercase
+            yield return EncodeToHex(code).ToLowerInvariant();
+#pragma warning restore CA1308 // Normalize strings to uppercase
+        }
+    }
+
+    private static string EncodeToHex(byte characterCode)
+    {
+#pragma warning disable CA1308 // Normalize strings to uppercase
+        return BitConverter.ToString(new[] { characterCode }).ToLowerInvariant();
+#pragma warning restore CA1308 // Normalize strings to uppercase
+    }
+
+    private static bool TryDecodeHex(string input, out byte b)
+    {
+        b = default;
+
+        try
+        {
+            b = Convert.ToByte(input, fromBase: 16);
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+        catch (OverflowException)
+        {
+            return false;
+        }
+    }
+
+    private string Encode(string rawValue)
+    {
+        StringBuilder sb = new();
+
+        foreach (char character in Ensure.Param(rawValue).Value)
+        {
+            if (this.IsSafeCharacter(character))
+            {
+                sb = sb.Append(character);
+            }
+            else
+            {
+                foreach (string str in this.EncodeToEscapCodes(character))
+                {
+                    sb = sb
+                            .Append(this.EscapeTokenStart)
+                            .Append(str)
+                            .Append(this.EscapeTokenEnd);
+                }
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private string Encode(IEnumerable<byte> rawBytes)
+    {
+        StringBuilder sb = new();
+
+        foreach (byte characterCode in Ensure.Param(rawBytes).Value)
+        {
+            if (this.IsSafeCharacterCode(characterCode))
+            {
+                sb = sb.Append((char)characterCode);
+            }
+            else
+            {
+                sb = sb
+                        .Append(this.EscapeTokenStart)
+                        .Append(this.EncodeToEscapeCode(characterCode))
+                        .Append(this.EscapeTokenEnd);
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private TokenDecoding TryReadStringLiteralInternal(
+            string input,
+            int startAt = 0,
+            bool disallowQuotation = false,
+            TokenString? parent = null)
+    {
+        Ensure.Param(input).Done();
+        Ensure.Param(startAt).InRange(0, input.Length).Done();
+
+        // empty source
+        if (string.IsNullOrEmpty(input) || startAt == input.Length)
+        {
+            if (disallowQuotation)
+            {
+                return new TokenString(
+                        input,
+                        startAt: startAt,
+                        endAt: startAt,
+                        continueAt: startAt,
+                        stringValue: string.Empty)
+                {
+                    Parent = parent,
+                };
+            }
+
+            // for required quotation this is failure
+            return new TokenFailure(
+                    input,
+                    startAt: startAt,
+                    endAt: startAt,
+                    formatErrorMessage: $"Missing literal boundary: {Dump.Literal(this.QuotationMarkStart)}")
+            {
+                Parent = parent,
+            };
+        }
+
+        // check for leading quotation mark
+        if (!disallowQuotation && input[startAt] != this.quotationMarkCharacter)
+        {
+            return new TokenNoMatch(input, startAt: startAt);
+        }
+        else if (disallowQuotation && input[startAt] == this.quotationMarkCharacter)
+        {
+            return new TokenFailure(
+                    input,
+                    startAt: startAt,
+                    endAt: startAt,
+                    formatErrorMessage: $"Disallowed character in encoded string literal content: {Dump.Literal(this.QuotationMarkStart)}")
+            {
+                Parent = parent,
+            };
+        }
+
+        bool inQuotation = false;
+        bool incompleteRead = false;
+        StringBuilder sb = new();
+        List<byte>? bytes = null;
+        int pos = -1 + startAt;
+        ParsedToken? lastReadToken = null;
+
+        foreach (ParsedToken token in this.stopWordParser.Parse(input, startAt: startAt))
+        {
+            lastReadToken = token;
+            pos += token.Length;
+
+            if (token == this.quotationMarkStopWord)
+            {
+                if (disallowQuotation)
+                {
+                    return new TokenFailure(
+                        input,
+                        startAt: startAt,
+                        endAt: pos,
+                        formatErrorMessage: $"Disallowed character in encoded string literal: {Dump.Literal(this.QuotationMarkStart)}")
+                    {
+                        Parent = parent,
+                    };
+                }
+
+                if (inQuotation)
+                {
+                    inQuotation = false;
+                    break;
+                }
+
+                inQuotation = true;
+                continue;
+            }
+
+            if (token is ParsedTokenControl incompleteControl && incompleteControl.IncompleteRead)
+            {
+                incompleteRead = true;
+                break;
+            }
+
+            // continue if ParsedTokenStopWord
+            if (token is ParsedTokenControl control && control.Length > 0)
+            {
+                if (this.controlToCommonEscapeCharacters.ContainsKey(control.Value[0]))
+                {
+                    if (bytes is null)
+                    {
+                        sb = sb.Append(this.controlToCommonEscapeCharacters[control.Value[0]]);
+                    }
+                    else
+                    {
+                        bytes.Add(this.controlToCommonEscapeCode[control.Value[0]]);
+                    }
+                }
+                else if (control.Value[0] == HexPrefix)
+                {
+                    if (!(control.Value.Length == 3 && TryDecodeHex(control.Value[1..], out byte b)))
+                    {
+                        return new TokenFailure(
+                            input,
+                            startAt: startAt,
+                            endAt: pos,
+                            formatErrorMessage: $"Invalid escape sequence: {Dump.Literal(control.Value)}")
+                        {
+                            Parent = parent,
+                        };
+                    }
+
+                    if (bytes is null)
+                    {
+                        bytes = new List<byte>(Encoding.UTF8.GetBytes(sb.ToString()));
+                        sb = sb.Clear();
+                    }
+
+                    bytes.Add(b);
+                }
+                else if (bytes is null)
+                {
+                    sb = sb.Append(control.Value);
+                }
+                else
+                {
+                    bytes.AddRange(Encoding.UTF8.GetBytes(control.Value));
+                }
+            }
+            else if (token is ParsedTokenFreeText txt)
+            {
+                if (bytes is null)
+                {
+                    sb = sb.Append(txt.Value);
+                }
+                else
+                {
+                    bytes.AddRange(Encoding.UTF8.GetBytes(txt.Value));
+                }
+            }
+        }
+
+        // incomplete reads
+        if (inQuotation || incompleteRead || lastReadToken == this.escapeTokenStopWord)
+        {
+            return new TokenFailure(
+                    input,
+                    startAt: startAt,
+                    endAt: pos,
+                    formatErrorMessage: "Unfinished string literal")
+            {
+                Parent = parent,
+            };
+        }
+
+        if (bytes is null)
+        {
+            return new TokenString(
+                    input,
+                    startAt: startAt,
+                    endAt: pos,
+                    continueAt: pos + 1,
+                    stringValue: sb.ToString())
+            {
+                Parent = parent,
+            };
+        }
+
+        return new TokenBinary(
+                input,
+                startAt: startAt,
+                endAt: pos,
+                continueAt: pos + 1,
+                bytes: bytes)
+        {
+            Parent = parent,
+        };
+    }
+
+    private StopWordStringParser ConstructStopWordParser()
+    {
+        return new StopWordStringParser(
+                new HashSet<ParsedTokenStopWord>(new[] { this.quotationMarkStopWord, this.escapeTokenStopWord }),
+                state =>
+                {
+                    if (state.TriggeringStopWord == this.escapeTokenStopWord)
+                    {
+                        if (state.ReadBuffer.Length == 0)
+                        {
+                            return ParseAction.ReadMoreControl;
+                        }
+                        else if (state.ReadBuffer.Length == 1)
+                        {
+                            if (state.ReadBuffer[0] == HexPrefix)
+                            {
+                                return ParseAction.ContinueWithControllUntil(3);
+                            }
+
+                            return ParseAction.YieldControl;
+                        }
+                    }
+
+                    return ParseAction.Continue;
+                });
+    }
+
+    private bool IsSafeCharacter(char character)
+    {
+        if (character == this.quotationMarkCharacter)
+        {
+            return false;
+        }
+        else if (character == this.escapeTokenCharacter)
+        {
+            return false;
+        }
+        else if (character is >= ' ' and <= '~')
+        {
+            /* printable region */
+            return true;
+        }
+        else if (this.commonEscapeCharacters.ContainsKey(character))
+        {
+            return !this.PreferCommonEscapeSequences;
+        }
+        else if (this.EscapeNonAlphanumericAsBinary)
+        {
+            return false;
+        }
+        else
+        {
+            return char.IsLetterOrDigit(character)
+                    || char.IsPunctuation(character);
+        }
+    }
+
+    private bool IsSafeCharacterCode(byte characterCode)
+    {
+        if (characterCode == (byte)this.quotationMarkCharacter)
+        {
+            return false;
+        }
+        else if (characterCode == (byte)this.escapeTokenCharacter)
+        {
+            return false;
+        }
+        else if (characterCode is >= (byte)' ' and <= (byte)'~')
+        {
+            /* printable region */
+            return true;
+        }
+        else if (this.commonEscapeCodes.ContainsKey(characterCode))
+        {
+            return !this.PreferCommonEscapeSequences;
+        }
+        else
+        {
+            return false;
+        }
+    }
+
+    private IEnumerable<string> EncodeToEscapCodes(char character)
+    {
+        if (character == this.quotationMarkCharacter)
+        {
+            yield return this.quotationMarkStopWord.Value;
+        }
+        else if (character == this.escapeTokenCharacter)
+        {
+            yield return this.escapeTokenStopWord.Value;
+        }
+        else if (this.commonEscapeCharacters.ContainsKey(character))
+        {
+            yield return new string(this.commonEscapeCharacters[character], 1);
+        }
+        else
+        {
+            foreach (string str in EncodeToHex(character))
+            {
+                yield return $"{HexPrefix}{str}";
+            }
+        }
+    }
+
+    private string EncodeToEscapeCode(byte characterCode)
+    {
+        if (characterCode == this.quotationMarkCharacter)
+        {
+            return this.quotationMarkStopWord.Value;
+        }
+        else if (characterCode == this.escapeTokenCharacter)
+        {
+            return this.escapeTokenStopWord.Value;
+        }
+        else if (this.commonEscapeCodes.ContainsKey(characterCode))
+        {
+            return new string(this.commonEscapeCodes[characterCode], 1);
+        }
+        else
+        {
+            return $"{HexPrefix}{EncodeToHex(characterCode)}";
+        }
+    }
+}

--- a/src/Radicle.Common/src/Tokenization/IStringLiteralDefinition.cs
+++ b/src/Radicle.Common/src/Tokenization/IStringLiteralDefinition.cs
@@ -1,0 +1,93 @@
+﻿namespace Radicle.Common.Tokenization;
+
+using System;
+using Radicle.Common.Tokenization.Models;
+
+/// <summary>
+/// Definition for encoding string literals.
+/// </summary>
+public interface IStringLiteralDefinition
+{
+    /// <summary>
+    /// Gets Quotation mark start character.
+    /// </summary>
+    string QuotationMarkStart { get; }
+
+    /// <summary>
+    /// Gets Quotation mark end character.
+    /// </summary>
+    string QuotationMarkEnd { get; }
+
+    /// <summary>
+    /// Gets escape start character.
+    /// </summary>
+    string EscapeTokenStart { get; }
+
+    /// <summary>
+    /// Gets escape end character.
+    /// </summary>
+    string EscapeTokenEnd { get; }
+
+    /// <summary>
+    /// Encode given value to escaped string with no literal boundaries.
+    /// See <see cref="GetLiteral(TokenWithValue)"/>.
+    /// </summary>
+    /// <param name="value">Value to encode.</param>
+    /// <returns>Encoded string with no quotation marks.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    public string Encode(TokenWithValue value);
+
+    /// <summary>
+    /// Encode given raw value to escaped string literal with boundaries.
+    /// </summary>
+    /// <param name="value">Value to encode.</param>
+    /// <returns>Encoded string with quotation marks.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    public string GetLiteral(TokenWithValue value);
+
+    /// <summary>
+    /// Decode given escaped string with no with no literal boundaries
+    /// (quotation marks).
+    /// </summary>
+    /// <param name="input">Input to decode.</param>
+    /// <returns>instance of <see cref="TokenBinary"/>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    public TokenMatch Decode(string input);
+
+    /// <summary>
+    /// Try to read the string literal from <paramref name="input"/>
+    /// with position starting at <paramref name="startAt"/>.
+    /// </summary>
+    /// <param name="input">Input to read.</param>
+    /// <param name="startAt">Start position for parsing,
+    ///     it is in inclusive range [0, input length]s.</param>
+    /// <returns>instance of <see cref="TokenBinary"/>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown
+    ///     if <paramref name="startAt"/> is out of bounds
+    ///     of <paramref name="input"/> (i.e. outside [0, input_length]).</exception>
+    public TokenDecoding TryReadStringLiteral(
+            string input,
+            int startAt = 0);
+
+    /// <summary>
+    /// Try to read the string literal from <paramref name="input"/>
+    /// with position starting at <paramref name="startAt"/>.
+    /// </summary>
+    /// <param name="input">Input to read.</param>
+    /// <param name="startAt">Start position for parsing,
+    ///     it is in inclusive range [0, input length]s.</param>
+    /// <returns>instance of <see cref="TokenBinary"/>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown
+    ///     if <paramref name="startAt"/> is out of bounds
+    ///     of <paramref name="input"/> (i.e. outside [0, input_length]).</exception>
+    public TokenDecoding TryReadStringLiteral(
+            TokenString input,
+            int startAt = 0);
+}

--- a/src/Radicle.Common/src/Tokenization/IStringTokenizer.cs
+++ b/src/Radicle.Common/src/Tokenization/IStringTokenizer.cs
@@ -1,0 +1,59 @@
+namespace Radicle.Common.Tokenization;
+
+using System;
+using System.Collections.Generic;
+using Radicle.Common.Tokenization.Models;
+
+/// <summary>
+/// Interface of string tokenizer. Tokenizer can
+/// split given string to individual sub string tokens which can be
+/// used for further analysis. Note the tokens can have different
+/// length than the original input and be missing ignored parts
+/// by the specific tokenizer.
+/// </summary>
+public interface IStringTokenizer
+{
+    /*
+     How this work:
+
+     original input:
+                                      ignored parts from original input
+                                   ,_/_,
+                 |012.............................................................n| <-- string characters
+                   |               |   |                 |     |                  |
+    tokenizer 1    <-----t[1] 1---->   <-----t[1] 2------> ... <-t[1] n1 (binary)->  <- binary tokens are passed
+                   |               |   |                 |     |                  |
+    tokenizer 2    <t[2] 1> <t[2] 2>   <-----t[2] 3------>     |                  |
+                   |      | |      |   |                 |     |                  |
+    ...            |      | |      |   |                 |     |                  |
+                   |      | |      |   |                 |     |                  |
+    tokenizer x    <t[x] 1> <t[x] 2>   <t[x] 3-> <-t[x] 4>     <-t[x] nx (binary)-> <-- final set of tokens
+                                                                                        with their positions
+                                                                                        in original input
+     */
+
+    /// <summary>
+    /// Gets parent tokenizer which is applied before this tokenizer.
+    /// Note that binary decoded strings are not parsed further.
+    /// If undefined then this is the first tokenizer in the tokenization chain.
+    /// </summary>
+    IStringTokenizer? Parent { get; }
+
+    /// <summary>
+    /// Convert given <paramref name="input"/> string to tokens.
+    /// </summary>
+    /// <param name="input">Input to convert.</param>
+    /// <param name="startAt">Optional start position of the parsing.</param>
+    /// <returns>Collection of tokens, may be empty
+    ///     if <paramref name="input"/> yields no tokens.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    /// <exception cref="FormatException">Thrown
+    ///     if <paramref name="input"/> has format errors.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown
+    ///     if <paramref name="startAt"/> is out of allowed
+    ///     range [0, input_length].</exception>
+    IEnumerable<TokenWithValue> Parse(
+            string input,
+            int startAt = 0);
+}

--- a/src/Radicle.Common/src/Tokenization/Models/ParseAction.cs
+++ b/src/Radicle.Common/src/Tokenization/Models/ParseAction.cs
@@ -1,0 +1,83 @@
+﻿namespace Radicle.Common.Tokenization.Models;
+
+using System;
+using Radicle.Common.Check;
+
+/// <summary>
+/// Action to perform after stop word was encountered.
+/// </summary>
+public sealed class ParseAction
+{
+    /// <summary>
+    /// Action value for <see cref="ParseActionType.Continue"/>.
+    /// I.e. after yielding stop word continue parsing as ususal.
+    /// </summary>
+    public static readonly ParseAction Continue = new(ParseActionType.Continue);
+
+    /// <summary>
+    /// Action value for <see cref="ParseActionType.ReadMoreControl"/>.
+    /// I.e. after yielding stop word return with more control read
+    /// in <see cref="ParsedReadState.ReadBuffer"/>.
+    /// </summary>
+    public static readonly ParseAction ReadMoreControl = new(ParseActionType.ReadMoreControl);
+
+    /// <summary>
+    /// Action value for <see cref="ParseActionType.Continue"/>.
+    /// I.e. after yielding stop word yield control
+    /// from contents of <see cref="ParsedReadState.ReadBuffer"/>.
+    /// </summary>
+    public static readonly ParseAction YieldControl = new(ParseActionType.YieldControl);
+
+    /// <summary>
+    /// Action value for <see cref="ParseActionType.Continue"/>.
+    /// I.e. after yielding stop word yield free text
+    /// from contents of <see cref="ParsedReadState.ReadBuffer"/>.
+    /// </summary>
+    public static readonly ParseAction YieldFreeText = new(ParseActionType.YieldFreeText);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ParseAction"/> class.
+    /// </summary>
+    /// <param name="type">Type of the action.</param>
+    private ParseAction(ParseActionType type)
+    {
+        this.Type = type;
+    }
+
+    /// <summary>
+    /// Gets type of this action.
+    /// </summary>
+    public ParseActionType Type { get; }
+
+    /// <summary>
+    /// Gets amount of characters to read before yielding.
+    /// Defaults to zero if not applicable. Check <see cref="Type"/>
+    /// if this parameter has a meaning for given type.
+    /// </summary>
+    public byte NumberOfCharactersToRead { get; private init; }
+
+    /// <summary>
+    /// Return <see cref="ParseAction"/> with
+    /// <see cref="ParseActionType.ContinueWithControllUntil"/>
+    /// with given amount of characters to accumulate in buffer
+    /// until yielding control token.
+    /// </summary>
+    /// <param name="numberOfCharactersToRead">Number of
+    ///     characters to accumulate before yielding
+    ///     control token. If given amount of characters
+    ///     is not available in the input, incomplete read control
+    ///     token is returned.</param>
+    /// <returns>Instance of <see cref="ParseAction"/>.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown
+    ///     is <paramref name="numberOfCharactersToRead"/> is zero.</exception>
+    public static ParseAction ContinueWithControllUntil(byte numberOfCharactersToRead)
+    {
+        return new ParseAction(ParseActionType.ContinueWithControllUntil)
+        {
+            NumberOfCharactersToRead = Ensure
+                    .Param(numberOfCharactersToRead)
+                    .StrictlyPositive()
+                    .Value,
+        };
+    }
+}

--- a/src/Radicle.Common/src/Tokenization/Models/ParseActionType.cs
+++ b/src/Radicle.Common/src/Tokenization/Models/ParseActionType.cs
@@ -1,0 +1,43 @@
+﻿namespace Radicle.Common.Tokenization.Models;
+
+/// <summary>
+/// Enumeration of possible actions after yielding stop word.
+/// </summary>
+/// <remarks>Note there is no stop option here because the parser
+/// returns enumeration which can be stopped externally.
+/// This makes this a bit simplier.</remarks>
+public enum ParseActionType
+{
+    /// <summary>
+    /// After stop word there is no control, so just continue
+    /// as ususal in parsing.
+    /// </summary>
+    Continue = 0,
+
+    /// <summary>
+    /// Read further and retrigger parse action.
+    /// If input is exhausted incomplete control
+    /// token is returned immidiatelly.
+    /// </summary>
+    ReadMoreControl = 1,
+
+    /// <summary>
+    /// Yield control token with contents
+    /// of <see cref="ParsedReadState.ReadBuffer"/>
+    /// read so far as part of control sequence read.
+    /// </summary>
+    YieldControl = 2,
+
+    /// <summary>
+    /// Yield free text token with contents
+    /// of <see cref="ParsedReadState.ReadBuffer"/>
+    /// read so far as part of control sequence read.
+    /// </summary>
+    YieldFreeText = 3,
+
+    /// <summary>
+    /// Continue acumulating control token until given condition
+    /// yield that.
+    /// </summary>
+    ContinueWithControllUntil = 4,
+}

--- a/src/Radicle.Common/src/Tokenization/Models/ParsedReadState.cs
+++ b/src/Radicle.Common/src/Tokenization/Models/ParsedReadState.cs
@@ -1,0 +1,41 @@
+﻿namespace Radicle.Common.Tokenization.Models;
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Radicle.Common.Check;
+
+/// <summary>
+/// Read state of the parser which can be probed by custom action.
+/// </summary>
+public sealed class ParsedReadState
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ParsedReadState"/> class.
+    /// </summary>
+    /// <param name="readBuffer">Bufferof characters read after
+    ///     <paramref name="triggeringStopWord"/>.</param>
+    /// <param name="triggeringStopWord">Stop word which
+    ///     triggerred this state.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    public ParsedReadState(
+            IEnumerable<char> readBuffer,
+            ParsedTokenStopWord triggeringStopWord)
+    {
+        this.ReadBuffer = Ensure.Param(readBuffer).ToImmutableArray();
+        this.TriggeringStopWord = Ensure.Param(triggeringStopWord).Value;
+    }
+
+    /// <summary>
+    /// Gets buffer of read characters after <see cref="TriggeringStopWord"/>.
+    /// May be empty if the source input was exhausted.
+    /// This buffer size depends on the last <see cref="ParseAction"/>.
+    /// </summary>
+    public ImmutableArray<char> ReadBuffer { get; }
+
+    /// <summary>
+    /// Gets triggering stop word.
+    /// </summary>
+    public ParsedTokenStopWord TriggeringStopWord { get; }
+}

--- a/src/Radicle.Common/src/Tokenization/Models/ParsedToken.cs
+++ b/src/Radicle.Common/src/Tokenization/Models/ParsedToken.cs
@@ -1,0 +1,90 @@
+namespace Radicle.Common.Tokenization.Models;
+
+using System;
+using Radicle.Common.Check;
+
+/// <summary>
+/// Immutable representation of parsed token from stop word string parser,
+/// which can be either stop word, free text or control sequence.
+/// Note this data model has no failure handling, only incomplete read handling.
+/// </summary>
+public abstract class ParsedToken : IEquatable<ParsedToken>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ParsedToken"/> class.
+    /// </summary>
+    /// <param name="token">String value of this stope token.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    internal ParsedToken(string token)
+    {
+        this.Value = Ensure.Param(token).Value;
+    }
+
+    /// <summary>
+    /// Gets type of this token.
+    /// </summary>
+    public abstract ParsedTokenType Type { get; }
+
+    /// <summary>
+    /// Gets string value of this token.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Gets length of this token value.
+    /// </summary>
+    public int Length => this.Value.Length;
+
+    /// <summary>
+    /// Gets a value indicating whether this stop token is empty.
+    /// </summary>
+    public bool IsEmpty => this.Value.Length == 0;
+
+    /// <summary>
+    /// Equals.
+    /// </summary>
+    /// <param name="one">Left operand.</param>
+    /// <param name="other">Right operand.</param>
+    /// <returns><see langword="true"/> if equal.</returns>
+    public static bool operator ==(ParsedToken? one, ParsedToken? other)
+    {
+        return one is null ? other is null : one.Equals(other);
+    }
+
+    /// <summary>
+    /// Non equals.
+    /// </summary>
+    /// <param name="one">Left operand.</param>
+    /// <param name="other">Right operand.</param>
+    /// <returns><see langword="true"/> if not equal.</returns>
+    public static bool operator !=(ParsedToken? one, ParsedToken? other)
+    {
+        return !(one == other);
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+    {
+        return obj is ParsedToken token && this.Equals(token);
+    }
+
+    /// <inheritdoc />
+    public virtual bool Equals(ParsedToken? other)
+    {
+        return other is not null
+                && this.Value.Equals(other.Value, StringComparison.Ordinal);
+    }
+
+    /// <inheritdoc/>
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(this.Value);
+    }
+
+    /// <inheritdoc/>
+    public override string ToString()
+    {
+        return $"{Dump.Literal(this.Value)}";
+    }
+}

--- a/src/Radicle.Common/src/Tokenization/Models/ParsedTokenControl.cs
+++ b/src/Radicle.Common/src/Tokenization/Models/ParsedTokenControl.cs
@@ -1,0 +1,57 @@
+﻿namespace Radicle.Common.Tokenization.Models;
+
+using System;
+
+/// <summary>
+/// Immutable representation of the control token.
+/// This is a token which was preceeded by special stop word.
+/// </summary>
+public sealed class ParsedTokenControl : ParsedToken
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ParsedTokenControl"/> class.
+    /// </summary>
+    /// <param name="value">Character of the escape token.</param>
+    /// <param name="incompleteRead">Flag indicating incomplete read,
+    ///     a potential error.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    public ParsedTokenControl(
+            string value,
+            bool incompleteRead = false)
+            : base(value)
+    {
+        this.IncompleteRead = incompleteRead;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether this token is a result
+    /// of incomplete read, i.e. missing escape character.
+    /// </summary>
+    public bool IncompleteRead { get; }
+
+    /// <inheritdoc/>
+    public override ParsedTokenType Type => ParsedTokenType.Control;
+
+    /// <inheritdoc/>
+    public override bool Equals(ParsedToken? other)
+    {
+        return base.Equals(other)
+                && other is ParsedTokenControl c
+                && this.IncompleteRead == c.IncompleteRead;
+    }
+
+    /// <inheritdoc/>
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(this.Value, this.IncompleteRead);
+    }
+
+    /// <inheritdoc/>
+    public override string ToString()
+    {
+        string read = this.IncompleteRead ? "*" : string.Empty;
+
+        return $"[control] {base.ToString()}{read}";
+    }
+}

--- a/src/Radicle.Common/src/Tokenization/Models/ParsedTokenFreeText.cs
+++ b/src/Radicle.Common/src/Tokenization/Models/ParsedTokenFreeText.cs
@@ -1,0 +1,36 @@
+﻿namespace Radicle.Common.Tokenization.Models;
+
+using System;
+
+/// <summary>
+/// Immutable representaion of free text token between escape tokens.
+/// </summary>
+public sealed class ParsedTokenFreeText : ParsedToken
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ParsedTokenFreeText"/> class.
+    /// </summary>
+    /// <param name="token">Free text token.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    public ParsedTokenFreeText(string token)
+            : base(token)
+    {
+    }
+
+    /// <inheritdoc/>
+    public override ParsedTokenType Type => ParsedTokenType.FreeText;
+
+    /// <inheritdoc/>
+    public override bool Equals(ParsedToken? other)
+    {
+        return base.Equals(other)
+                && other is ParsedTokenFreeText;
+    }
+
+    /// <inheritdoc/>
+    public override string ToString()
+    {
+        return $"[free text] {base.ToString()}";
+    }
+}

--- a/src/Radicle.Common/src/Tokenization/Models/ParsedTokenStopWord.cs
+++ b/src/Radicle.Common/src/Tokenization/Models/ParsedTokenStopWord.cs
@@ -1,0 +1,76 @@
+﻿namespace Radicle.Common.Tokenization.Models;
+
+using System;
+using Radicle.Common.Check;
+
+/// <summary>
+/// Immutable representation of the parsed token stop word.
+/// Such token is stop word defined by the parser.
+/// </summary>
+public sealed class ParsedTokenStopWord : ParsedToken
+{
+    /// <summary>
+    /// Empty stop word.
+    /// </summary>
+    public static readonly ParsedTokenStopWord Empty = new(string.Empty);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ParsedTokenStopWord"/> class.
+    /// </summary>
+    /// <param name="value">Value of this stop word as read by parser.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown
+    ///     if <paramref name="value"/> is empty.</exception>
+    public ParsedTokenStopWord(string value)
+        : base(Ensure.Param(value).NotEmpty().Value)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ParsedTokenStopWord"/> class.
+    /// </summary>
+    /// <param name="character">Value of this stop word as read by parser.</param>
+    public ParsedTokenStopWord(char character)
+        : base(new string(character, 1))
+    {
+    }
+
+    /// <inheritdoc/>
+    public override ParsedTokenType Type => ParsedTokenType.StopWord;
+
+    /// <summary>
+    /// Convert given <paramref name="character"/>
+    /// to instance of <see cref="ParsedTokenStopWord"/>.
+    /// </summary>
+    /// <param name="character">Character to use.</param>
+    /// <returns>Instance of <see cref="ParsedTokenStopWord"/>.</returns>
+    public static implicit operator ParsedTokenStopWord(char character)
+    {
+        return ToParsedTokenStopWord(character);
+    }
+
+    /// <summary>
+    /// Convert given <paramref name="character"/>
+    /// to instance of <see cref="ParsedTokenStopWord"/>.
+    /// </summary>
+    /// <param name="character">Character to use.</param>
+    /// <returns>Instance of <see cref="ParsedTokenStopWord"/>.</returns>
+    public static ParsedTokenStopWord ToParsedTokenStopWord(char character)
+    {
+        return new ParsedTokenStopWord(character);
+    }
+
+    /// <inheritdoc/>
+    public override bool Equals(ParsedToken? other)
+    {
+        return base.Equals(other)
+                && other is ParsedTokenStopWord;
+    }
+
+    /// <inheritdoc/>
+    public override string ToString()
+    {
+        return $"[stop word] {base.ToString()}";
+    }
+}

--- a/src/Radicle.Common/src/Tokenization/Models/ParsedTokenType.cs
+++ b/src/Radicle.Common/src/Tokenization/Models/ParsedTokenType.cs
@@ -1,0 +1,22 @@
+﻿namespace Radicle.Common.Tokenization.Models;
+
+/// <summary>
+/// enumeration of all parsed token types.
+/// </summary>
+public enum ParsedTokenType
+{
+    /// <summary>
+    /// Stop word.
+    /// </summary>
+    StopWord = 0,
+
+    /// <summary>
+    /// Control sequence.
+    /// </summary>
+    Control = 1,
+
+    /// <summary>
+    /// Free text.
+    /// </summary>
+    FreeText = 2,
+}

--- a/src/Radicle.Common/src/Tokenization/Models/SimpleMarkdownText.cs
+++ b/src/Radicle.Common/src/Tokenization/Models/SimpleMarkdownText.cs
@@ -1,0 +1,111 @@
+namespace Radicle.Common.Tokenization.Models;
+
+using System;
+using System.Collections.Generic;
+using Radicle.Common.Check;
+
+/// <summary>
+/// Immutable representation of simple markdown text.
+/// This currently expects this limited text formatting:
+/// '*' surrounded text for bold, '_' for emphasised.
+/// </summary>
+public class SimpleMarkdownText
+{
+    /// <summary>
+    /// Stop stop word for bold formatting.
+    /// </summary>
+    public static readonly ParsedTokenStopWord BoldStopWord = new('*');
+
+    /// <summary>
+    /// Stop stop word for emphasised formatting.
+    /// </summary>
+    public static readonly ParsedTokenStopWord EmphasisedStopWord = new('_');
+
+    /// <summary>
+    /// Escape stop word.
+    /// </summary>
+    public static readonly ParsedTokenStopWord EscapeStopWord = new('\\');
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SimpleMarkdownText"/> class.
+    /// </summary>
+    /// <param name="value">Value.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    public SimpleMarkdownText(string value)
+    {
+        this.Value = Ensure.Param(value).Value;
+    }
+
+    /// <summary>
+    /// Gets value of this formatted text string.
+    /// May be empty.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Implicitly convert <see cref="string"/>
+    /// to instance of <see cref="SimpleMarkdownText"/>.
+    /// </summary>
+    /// <param name="value">Value to convert.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    public static implicit operator SimpleMarkdownText(string value)
+    {
+        return new SimpleMarkdownText(value);
+    }
+
+    /// <summary>
+    /// Implicitly convert <see cref="string"/>
+    /// to instance of <see cref="SimpleMarkdownText"/>.
+    /// </summary>
+    /// <param name="value">Value to convert.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    /// <returns>Instance of <see cref="SimpleMarkdownText"/>.</returns>
+    public static SimpleMarkdownText FromString(string value)
+    {
+        return new SimpleMarkdownText(value);
+    }
+
+    /// <summary>
+    /// Implicitly convert <see cref="string"/>
+    /// to instance of <see cref="SimpleMarkdownText"/>.
+    /// </summary>
+    /// <param name="values">Values to convert.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    /// <returns>Instance of <see cref="SimpleMarkdownText"/>.</returns>
+    public static IEnumerable<SimpleMarkdownText> FromStrings(
+            IEnumerable<string> values)
+    {
+        foreach (string md in Ensure.Param(values).AllNotNull())
+        {
+            yield return new SimpleMarkdownText(md);
+        }
+    }
+
+    /// <summary>
+    /// Sanitize the <paramref name="input"/>
+    /// to be displayed in the markdown text as is.
+    /// </summary>
+    /// <param name="input">Input to sanitize.</param>
+    /// <returns>Sanitized text.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    public static SimpleMarkdownText Sanitize(string input)
+    {
+        string esc = EscapeStopWord.Value;
+
+        return Ensure.Param(input).Value
+            .Replace(esc, esc + esc, StringComparison.Ordinal)
+            .Replace(EmphasisedStopWord.Value, esc + EmphasisedStopWord.Value, StringComparison.Ordinal)
+            .Replace(BoldStopWord.Value, esc + BoldStopWord.Value, StringComparison.Ordinal);
+    }
+
+    /// <inheritdoc/>
+    public override string ToString()
+    {
+        return this.Value;
+    }
+}

--- a/src/Radicle.Common/src/Tokenization/Models/TokenBinary.cs
+++ b/src/Radicle.Common/src/Tokenization/Models/TokenBinary.cs
@@ -1,0 +1,103 @@
+﻿namespace Radicle.Common.Tokenization.Models;
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Radicle.Common.Check;
+
+/// <summary>
+/// Immutable represetnation of token with binary value.
+/// </summary>
+public sealed class TokenBinary : TokenWithValue
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TokenBinary"/> class.
+    /// </summary>
+    /// <remarks>Note <paramref name="bytes"/> does not have
+    ///     clear connection with form and length of <paramref name="sourceString"/>.
+    ///     It depends on decoder or tokenizer on how given string input
+    ///     is translated to bytes.</remarks>
+    /// <param name="sourceString">Source string.</param>
+    /// <param name="startAt">Inclusive position of start of decoding.</param>
+    /// <param name="endAt">Inclusive position of end of decoding.</param>
+    /// <param name="continueAt">Position immidiatelly after
+    ///     string token in <paramref name="sourceString"/> or equal to
+    ///     length of <paramref name="sourceString"/>. If this is equal to
+    ///     lenght of <paramref name="sourceString"/> then the input was exhausted.</param>
+    /// <param name="bytes">Decoded bytes.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown
+    ///     if positions are out of allowed range [0, input_length]
+    ///     or <paramref name="startAt"/> is larger then <paramref name="endAt"/>
+    ///     or <paramref name="continueAt"/> is smaller than <paramref name="endAt"/>.</exception>
+    public TokenBinary(
+            string sourceString,
+            int startAt,
+            int endAt,
+            int continueAt,
+            IEnumerable<byte> bytes)
+        : base(sourceString, startAt, endAt, continueAt)
+    {
+        this.Bytes = Ensure
+                .Collection(bytes)
+                .ToImmutableArray();
+    }
+
+    /// <summary>
+    /// Gets decoded bytes. Can be empty, as empty string token.
+    /// </summary>
+    public ImmutableArray<byte> Bytes { get; } = ImmutableArray<byte>.Empty;
+
+    /// <summary>
+    /// Get pass through instance of <see cref="TokenString"/>
+    /// with <paramref name="input"/> and value equal to substring of this
+    /// <paramref name="input"/>.
+    /// Bytes are obtaint assuming UTF-8 encoding.
+    /// </summary>
+    /// <param name="input">Original input string.</param>
+    /// <param name="startAt">Inclusive oosition of start of decoding,
+    ///     this can be start of literal or just encoded value.</param>
+    /// <returns>Instance of <see cref="TokenBinary"/>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown
+    ///     if <paramref name="startAt"/> is out of allowed
+    ///     range [0, input_length].</exception>
+    public static TokenBinary GetPassThrough(
+            IEnumerable<byte> input,
+            int startAt = 0)
+    {
+        Ensure.Param(input).Done();
+
+        int inputLength = input.Count();
+
+        Ensure.Param(startAt).InRange(0, inputLength).Done();
+
+        IEnumerable<byte> value;
+
+        if (startAt != 0)
+        {
+            if (startAt == inputLength)
+            {
+                value = Array.Empty<byte>();
+            }
+            else
+            {
+                value = input.Skip(startAt);
+            }
+        }
+        else
+        {
+            value = input;
+        }
+
+        return new TokenBinary(
+                string.Empty,
+                startAt,
+                endAt: startAt + Math.Max(inputLength - startAt - 1, 0),
+                continueAt: startAt + inputLength - startAt,
+                bytes: value);
+    }
+}

--- a/src/Radicle.Common/src/Tokenization/Models/TokenDecoding.cs
+++ b/src/Radicle.Common/src/Tokenization/Models/TokenDecoding.cs
@@ -1,0 +1,64 @@
+﻿namespace Radicle.Common.Tokenization.Models;
+
+using System;
+using Radicle.Common.Check;
+
+/// <summary>
+/// Base of immutable token decodigns with failure handling.
+/// </summary>
+public abstract class TokenDecoding
+{
+    /*
+       Token decoding class hierarchy:
+
+              TokenDecoding
+            /               \
+     TokenNoMatch        TokenMatch
+                       /            \
+                TokenFailure      TokenWith
+                                /         \
+                    TokenWithNoValue     TokenWithValue
+                                         /             \
+                                   TokenBinary     TokenString
+    */
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TokenDecoding"/> class.
+    /// </summary>
+    /// <param name="sourceString">Source string.</param>
+    /// <param name="startAt">Inclusive position of start of decoding.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown
+    ///     if positions are out of allowed range [0, input_length].</exception>
+    internal TokenDecoding(
+            string sourceString,
+            int startAt)
+    {
+        this.SourceString = Ensure.Param(sourceString).Value;
+        this.StartAt = Ensure.Param(startAt).InRange(0, sourceString.Length).Value;
+    }
+
+    /// <summary>
+    /// Gets parent of this decoded string if any.
+    /// The parent has string representation and its
+    /// value is equal to <see cref="SourceString"/>.
+    /// </summary>
+    /// <remarks>Parent can be used to make multistace tokenization
+    /// where parent tokens are again tokeninzed by child tokenizer.</remarks>
+    public TokenString? Parent { get; init; }
+
+    /// <summary>
+    /// Gets original value of the source this token was made from.
+    /// Can be empty.
+    /// </summary>
+    public string SourceString { get; } = string.Empty;
+
+    /// <summary>
+    /// Gets position in <see cref="SourceString"/> where token
+    /// decoding happened (inclusive). It is in range
+    /// [0, source_string_length], with upper bound
+    /// leading to empty token.
+    /// </summary>
+    public int StartAt { get; }
+}

--- a/src/Radicle.Common/src/Tokenization/Models/TokenFailure.cs
+++ b/src/Radicle.Common/src/Tokenization/Models/TokenFailure.cs
@@ -1,0 +1,43 @@
+﻿namespace Radicle.Common.Tokenization.Models;
+
+using System;
+using Radicle.Common.Check;
+
+/// <summary>
+/// Immutable representation of token decoding failure.
+/// </summary>
+public sealed class TokenFailure : TokenMatch
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TokenFailure"/> class.
+    /// </summary>
+    /// <param name="sourceString">Source string.</param>
+    /// <param name="startAt">Inclusive position of start of decoding.</param>
+    /// <param name="endAt">Inclusive position of end of decoding, i.e.
+    ///     where the error was encountered.</param>
+    /// <param name="formatErrorMessage">Error message in case of error.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown
+    ///     if <paramref name="formatErrorMessage"/> is empty or blank
+    ///     or positions are out of allowed range [0, input_length]
+    ///     of <paramref name="startAt"/> is larger then <paramref name="endAt"/>.</exception>
+    public TokenFailure(
+            string sourceString,
+            int startAt,
+            int endAt,
+            string formatErrorMessage)
+        : base(sourceString, startAt, endAt)
+    {
+        this.FormatErrorMessage = Ensure
+                .Param(formatErrorMessage)
+                .NotWhiteSpace()
+                .Value;
+    }
+
+    /// <summary>
+    /// Gets short human readable message explaining format error.
+    /// Can be empty in case of no error.
+    /// </summary>
+    public string FormatErrorMessage { get; }
+}

--- a/src/Radicle.Common/src/Tokenization/Models/TokenMatch.cs
+++ b/src/Radicle.Common/src/Tokenization/Models/TokenMatch.cs
@@ -1,0 +1,56 @@
+﻿namespace Radicle.Common.Tokenization.Models;
+
+using System;
+using Radicle.Common.Check;
+
+/// <summary>
+/// Immutable representation of token match.
+/// This can be successfull or not.
+/// </summary>
+public abstract class TokenMatch : TokenDecoding
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TokenMatch"/> class.
+    /// </summary>
+    /// <param name="sourceString">Source string.</param>
+    /// <param name="startAt">Inclusive position of start of decoding.</param>
+    /// <param name="endAt">Inclusive position of end of decoding.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown
+    ///     if positions are out of allowed range [0, input_length]
+    ///     or <paramref name="startAt"/> is larger then <paramref name="endAt"/>.</exception>
+    internal TokenMatch(
+            string sourceString,
+            int startAt,
+            int endAt)
+        : base(sourceString, startAt)
+    {
+        this.EndAt = Ensure.Param(endAt).GreaterThanOrEqual(startAt).Value;
+    }
+
+    /// <summary>
+    /// Gets position in <see cref="TokenDecoding.SourceString"/> where literal was ended (inclusive).
+    /// In case of <see cref="TokenFailure"/> it is last read position
+    /// with formatting error.
+    /// </summary>
+    public int EndAt { get; }
+
+    /// <summary>
+    /// Gets position in root parent <see cref="TokenDecoding.SourceString"/> where literal was ended (inclusive).
+    /// In case of <see cref="TokenFailure"/> it is last read position
+    /// with formatting error.
+    /// </summary>
+    public int RootEndAt
+    {
+        get
+        {
+            if (this.Parent is null)
+            {
+                return this.EndAt;
+            }
+
+            return this.EndAt + this.Parent.StartAt;
+        }
+    }
+}

--- a/src/Radicle.Common/src/Tokenization/Models/TokenNoMatch.cs
+++ b/src/Radicle.Common/src/Tokenization/Models/TokenNoMatch.cs
@@ -1,0 +1,25 @@
+﻿namespace Radicle.Common.Tokenization.Models;
+
+using System;
+
+/// <summary>
+/// Immutable representation of no-match for token decoding.
+/// E.g. if the probed input does not contain expected token form,
+/// then this will be the result of decoding.
+/// </summary>
+public sealed class TokenNoMatch : TokenDecoding
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TokenNoMatch"/> class.
+    /// </summary>
+    /// <param name="sourceString">Source string.</param>
+    /// <param name="startAt">Inclusive position of start of decoding.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown
+    ///     if positions are out of allowed range [0, input_length].</exception>
+    public TokenNoMatch(string sourceString, int startAt)
+            : base(sourceString, startAt)
+    {
+    }
+}

--- a/src/Radicle.Common/src/Tokenization/Models/TokenString.cs
+++ b/src/Radicle.Common/src/Tokenization/Models/TokenString.cs
@@ -1,0 +1,148 @@
+﻿namespace Radicle.Common.Tokenization.Models;
+
+using System;
+using Radicle.Common.Check;
+
+/// <summary>
+/// Structure definiting result of attempt to read string literal.
+/// </summary>
+public sealed class TokenString : TokenWithValue
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TokenString"/> class.
+    /// </summary>
+    /// <remarks>Note <paramref name="stringValue"/> does not have
+    ///     clear connection with form and length of <paramref name="sourceString"/>.
+    ///     It depends on decoder or tokenizer on how given string input
+    ///     is translated to bytes.</remarks>
+    /// <param name="sourceString">Source string.</param>
+    /// <param name="startAt">Inclusive position of start of decoding.</param>
+    /// <param name="endAt">Inclusive position of end of decoding.</param>
+    /// <param name="continueAt">Position immidiatelly after
+    ///     string token in <paramref name="sourceString"/> or equal to
+    ///     length of <paramref name="sourceString"/>. If this is equal to
+    ///     lenght of <paramref name="sourceString"/> then the input was exhausted.</param>
+    /// <param name="stringValue">Decoded string.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown
+    ///     if positions are out of allowed range [0, input_length]
+    ///     or <paramref name="startAt"/> is larger then <paramref name="endAt"/>
+    ///     or <paramref name="continueAt"/> is smaller than <paramref name="endAt"/>.</exception>
+    public TokenString(
+            string sourceString,
+            int startAt,
+            int endAt,
+            int continueAt,
+            string stringValue)
+        : base(sourceString, startAt, endAt, continueAt)
+    {
+        this.StringValue = Ensure
+                .Param(stringValue)
+                .Value;
+    }
+
+    /// <summary>
+    /// Gets decoded bytes. Can be empty, as empty string token.
+    /// </summary>
+    public string StringValue { get; } = string.Empty;
+
+    /// <summary>
+    /// Get pass through instance of <see cref="TokenString"/>
+    /// with <paramref name="input"/> and value equal to substring of this
+    /// <paramref name="input"/>.
+    /// Bytes are obtaint assuming UTF-8 encoding.
+    /// </summary>
+    /// <param name="input">Original input string.</param>
+    /// <param name="startAt">Inclusive oosition of start of decoding,
+    ///     this can be start of literal or just encoded value.</param>
+    /// <returns>Instance of <see cref="TokenBinary"/>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown
+    ///     if <paramref name="startAt"/> is out of allowed
+    ///     range [0, input_length].</exception>
+    public static TokenString GetPassThrough(
+            string input,
+            int startAt = 0)
+    {
+        Ensure.Param(input).Done();
+        Ensure.Param(startAt).InRange(0, input.Length).Done();
+
+        string stringValue;
+
+        if (startAt != 0)
+        {
+            if (startAt == input.Length)
+            {
+                stringValue = string.Empty;
+            }
+            else
+            {
+                stringValue = input[startAt..];
+            }
+        }
+        else
+        {
+            stringValue = input;
+        }
+
+        return new TokenString(
+                input,
+                startAt,
+                endAt: startAt + Math.Max(stringValue.Length - 1, 0),
+                continueAt: startAt + stringValue.Length,
+                stringValue: stringValue);
+    }
+
+    /// <summary>
+    /// Get pass through instance of <see cref="TokenString"/>
+    /// with <paramref name="input"/> and value equal to substring of this
+    /// <paramref name="input"/>.
+    /// Bytes are obtaint assuming UTF-8 encoding.
+    /// </summary>
+    /// <param name="input">Original input string.</param>
+    /// <param name="startAt">Inclusive oosition of start of decoding,
+    ///     this can be start of literal or just encoded value.</param>
+    /// <returns>Instance of <see cref="TokenBinary"/>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown
+    ///     if <paramref name="startAt"/> is out of allowed
+    ///     range [0, input_length].</exception>
+    public static TokenString GetPassThrough(
+            TokenString input,
+            int startAt = 0)
+    {
+        Ensure.Param(input).Done();
+        Ensure.Param(startAt).InRange(0, input.StringValue.Length).Done();
+
+        string stringValue;
+
+        if (startAt != 0)
+        {
+            if (startAt == input.StringValue.Length)
+            {
+                stringValue = string.Empty;
+            }
+            else
+            {
+                stringValue = input.StringValue[startAt..];
+            }
+        }
+        else
+        {
+            stringValue = input.StringValue;
+        }
+
+        return new TokenString(
+                input.StringValue,
+                startAt,
+                endAt: startAt + Math.Max(stringValue.Length - 1, 0),
+                continueAt: startAt + stringValue.Length,
+                stringValue: stringValue)
+        {
+            Parent = input,
+        };
+    }
+}

--- a/src/Radicle.Common/src/Tokenization/Models/TokenWith.cs
+++ b/src/Radicle.Common/src/Tokenization/Models/TokenWith.cs
@@ -1,0 +1,49 @@
+﻿namespace Radicle.Common.Tokenization.Models;
+
+using System;
+using Radicle.Common.Check;
+
+/// <summary>
+/// Immutable base for no-value as well as value tokens.
+/// </summary>
+public abstract class TokenWith : TokenMatch
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TokenWith"/> class.
+    /// </summary>
+    /// <param name="sourceString">Source string.</param>
+    /// <param name="startAt">Inclusive position of start of decoding.</param>
+    /// <param name="endAt">Inclusive position of end of decoding.</param>
+    /// <param name="continueAt">Position immidiatelly after
+    ///     string token in <paramref name="sourceString"/> or equal to
+    ///     length of <paramref name="sourceString"/>. If this is equal to
+    ///     lenght of <paramref name="sourceString"/> then the input was exhausted.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown
+    ///     if positions are out of allowed range [0, input_length]
+    ///     or <paramref name="startAt"/> is larger then <paramref name="endAt"/>
+    ///     or <paramref name="continueAt"/> is smaller than <paramref name="endAt"/>.</exception>
+    internal TokenWith(
+            string sourceString,
+            int startAt,
+            int endAt,
+            int continueAt)
+        : base(sourceString, startAt, endAt)
+    {
+        if (continueAt != sourceString.Length)
+        {
+            this.ContinueAt = Ensure.Param(continueAt).GreaterThan(endAt).Value;
+        }
+        else
+        {
+            this.ContinueAt = continueAt;
+        }
+    }
+
+    /// <summary>
+    /// Gets exit position to continue reading of input on.
+    /// If it is equal to the input length the source was exhausted.
+    /// </summary>
+    public int ContinueAt { get; }
+}

--- a/src/Radicle.Common/src/Tokenization/Models/TokenWithNoValue.cs
+++ b/src/Radicle.Common/src/Tokenization/Models/TokenWithNoValue.cs
@@ -1,0 +1,36 @@
+﻿namespace Radicle.Common.Tokenization.Models;
+
+using System;
+using Radicle.Common.Check;
+
+/// <summary>
+/// Immutable representation of no-value token,
+/// which was produced from the source but yield nothing.
+/// </summary>
+public sealed class TokenWithNoValue : TokenWith
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TokenWithNoValue"/> class.
+    /// </summary>
+    /// <param name="sourceString">Source string.</param>
+    /// <param name="startAt">Inclusive position of start of decoding.</param>
+    /// <param name="endAt">Inclusive position of end of decoding.</param>
+    /// <param name="continueAt">Position immidiatelly after
+    ///     string token in <paramref name="sourceString"/> or equal to
+    ///     length of <paramref name="sourceString"/>. If this is equal to
+    ///     lenght of <paramref name="sourceString"/> then the input was exhausted.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown
+    ///     if positions are out of allowed range [0, input_length]
+    ///     or <paramref name="startAt"/> is larger then <paramref name="endAt"/>
+    ///     or <paramref name="continueAt"/> is smaller than <paramref name="endAt"/>.</exception>
+    public TokenWithNoValue(
+            string sourceString,
+            int startAt,
+            int endAt,
+            int continueAt)
+        : base(Ensure.Param(sourceString).Value, startAt, endAt, continueAt)
+    {
+    }
+}

--- a/src/Radicle.Common/src/Tokenization/Models/TokenWithValue.cs
+++ b/src/Radicle.Common/src/Tokenization/Models/TokenWithValue.cs
@@ -1,0 +1,87 @@
+﻿namespace Radicle.Common.Tokenization.Models;
+
+using System;
+using System.Collections.Generic;
+
+/// <summary>
+/// Immutable representation of token with value.
+/// </summary>
+public abstract class TokenWithValue : TokenWith
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TokenWithValue"/> class.
+    /// </summary>
+    /// <param name="sourceString">Source string.</param>
+    /// <param name="startAt">Inclusive position of start of decoding.</param>
+    /// <param name="endAt">Inclusive position of end of decoding.</param>
+    /// <param name="continueAt">Position immidiatelly after
+    ///     string token in <paramref name="sourceString"/> or equal to
+    ///     length of <paramref name="sourceString"/>. If this is equal to
+    ///     lenght of <paramref name="sourceString"/> then the input was exhausted.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown
+    ///     if positions are out of allowed range [0, input_length]
+    ///     or <paramref name="startAt"/> is larger then <paramref name="endAt"/>
+    ///     or <paramref name="continueAt"/> is smaller than <paramref name="endAt"/>.</exception>
+    internal TokenWithValue(
+            string sourceString,
+            int startAt,
+            int endAt,
+            int continueAt)
+        : base(sourceString, startAt, endAt, continueAt)
+    {
+    }
+
+    /// <summary>
+    /// Convert given <paramref name="value"/>
+    /// to instance of <see cref="TokenWithValue"/>.
+    /// </summary>
+    /// <param name="value">Value to use.</param>
+    /// <returns>Instance of <see cref="TokenWithValue"/>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    public static implicit operator TokenWithValue(string value)
+    {
+        return ToTokenWithValue(value);
+    }
+
+    /// <summary>
+    /// Convert given <paramref name="value"/>
+    /// to instance of <see cref="TokenWithValue"/>.
+    /// </summary>
+    /// <param name="value">Value to use.</param>
+    /// <returns>Instance of <see cref="TokenWithValue"/>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    public static implicit operator TokenWithValue(byte[] value)
+    {
+        return ToTokenWithValue(value);
+    }
+
+    /// <summary>
+    /// Convert given <paramref name="value"/>
+    /// to instance of <see cref="TokenWithValue"/>.
+    /// </summary>
+    /// <param name="value">Value to use.</param>
+    /// <returns>Instance of <see cref="TokenWithValue"/>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    public static TokenWithValue ToTokenWithValue(string value)
+    {
+        return TokenString.GetPassThrough(value);
+    }
+
+    /// <summary>
+    /// Convert given <paramref name="value"/>
+    /// to instance of <see cref="TokenWithValue"/>.
+    /// </summary>
+    /// <param name="value">Value to use.</param>
+    /// <returns>Instance of <see cref="TokenWithValue"/>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    public static TokenWithValue ToTokenWithValue(IEnumerable<byte> value)
+    {
+        return TokenBinary.GetPassThrough(value);
+    }
+}

--- a/src/Radicle.Common/src/Tokenization/StopWordStringParser.cs
+++ b/src/Radicle.Common/src/Tokenization/StopWordStringParser.cs
@@ -1,0 +1,264 @@
+namespace Radicle.Common.Tokenization;
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Radicle.Common.Check;
+using Radicle.Common.Tokenization.Models;
+
+/// <summary>
+/// Parser for the string containing stop characters or words.
+/// </summary>
+public sealed class StopWordStringParser
+{
+    private readonly ImmutableHashSet<ParsedTokenStopWord> stopWords;
+
+    private readonly int shortestStopWord;
+
+    private readonly Func<ParsedReadState, ParseAction>? controlTokenAction;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StopWordStringParser"/> class.
+    /// </summary>
+    /// <param name="stopWords">Optional stop chars.</param>
+    /// <param name="controlTokenAction">Optional action
+    ///     resolver for control tokens after stop words.</param>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if <paramref name="stopWords"/> contains <see langword="null"/>
+    ///     values.</exception>
+    public StopWordStringParser(
+            ISet<ParsedTokenStopWord>? stopWords = null,
+            Func<ParsedReadState, ParseAction>? controlTokenAction = null)
+    {
+        this.stopWords = Ensure.OptionalCollection(stopWords)
+                .AllNotNull()
+                .ToImmutableHashSet();
+        this.shortestStopWord = this.stopWords.Count > 0
+                ? this.stopWords.Min(w => w.Length)
+                : 0;
+        this.controlTokenAction = controlTokenAction;
+    }
+
+    /// <summary>
+    /// Parse given <paramref name="input"/>
+    /// according to this parser rules to tokens.
+    /// </summary>
+    /// <param name="input">Input to parse.</param>
+    /// <param name="startAt">Start position of the parsing.
+    ///     if equal to length of <paramref name="input"/>
+    ///     empty enumeration is returned.</param>
+    /// <returns>Collection of parsed tokens.</returns>
+    /// <exception cref="ArgumentNullException">Thrown
+    ///     if required parameter is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown
+    ///     if <paramref name="startAt"/> is out of bounds of
+    ///     <paramref name="input"/> [0, length_of_string].</exception>
+    /// <exception cref="NotSupportedException">Thrown in case of bug.</exception>
+    public IEnumerable<ParsedToken> Parse(
+            string input,
+            int startAt = 0)
+    {
+        Ensure.Param(input).Done();
+        Ensure.Param(startAt).InRange(0, input.Length).Done();
+
+        /* TODO: use spans */
+
+        List<char> buffer = new();
+        bool inControlSequence = false;
+        byte numberOfCharactersToRead = 0;
+        ParsedTokenStopWord? stopWord = null;
+
+        for (int position = startAt; position < input.Length; position++)
+        {
+            char current = input[position];
+            buffer.Add(current);
+
+            // read only control token which does not contain stop words
+            if (inControlSequence)
+            {
+                // ContinueWithControllUntil
+                if (numberOfCharactersToRead > 0)
+                {
+                    if (buffer.Count >= numberOfCharactersToRead)
+                    {
+                        yield return new ParsedTokenControl(new string(buffer.ToArray()));
+                        inControlSequence = false;
+                        stopWord = null;
+                        numberOfCharactersToRead = 0;
+                        buffer.Clear();
+                    }
+
+                    /* else continue */
+                }
+                else
+                {
+                    // ReadMoreControl
+                    ParseAction action = this.controlTokenAction!(new ParsedReadState(buffer, stopWord!));
+
+                    switch (action.Type)
+                    {
+                        case ParseActionType.Continue:
+                            break;
+                        case ParseActionType.ReadMoreControl:
+                            continue;
+                        case ParseActionType.YieldControl:
+                            yield return new ParsedTokenControl(new string(buffer.ToArray()));
+                            buffer.Clear();
+                            break;
+                        case ParseActionType.YieldFreeText:
+                            yield return new ParsedTokenFreeText(new string(buffer.ToArray()));
+                            buffer.Clear();
+                            break;
+                        case ParseActionType.ContinueWithControllUntil:
+                            numberOfCharactersToRead = action.NumberOfCharactersToRead;
+
+                            if (buffer.Count == numberOfCharactersToRead)
+                            {
+                                yield return new ParsedTokenControl(new string(buffer.ToArray()));
+                                numberOfCharactersToRead = 0;
+                                buffer.Clear();
+                            }
+                            else if (buffer.Count > numberOfCharactersToRead)
+                            {
+                                throw new NotSupportedException(
+                                        $"Control token action function requested to read {numberOfCharactersToRead} "
+                                        + $"characters of control token while buffer has already {buffer.Count} characters. "
+                                        + "This is bug in the control token action function!");
+                            }
+
+                            continue;
+                        default:
+                            throw new NotSupportedException(
+                                    $"BUG: Parse action type {action.Type} is not implemented.");
+                    }
+
+                    // all except ReadMoreControl and ContinueWithControllUntil
+                    inControlSequence = false;
+                    stopWord = null;
+
+                    // buffer is not cleared in case of ContinueWithFreeText
+                }
+            }
+            else if (this.TryGetStopWord(buffer, out stopWord))
+            {
+                int headLength = buffer.Count - stopWord.Length;
+
+                // yield part of the buffer which is not stop word
+                if (headLength > 0)
+                {
+                    string head = new(buffer.Take(headLength).ToArray());
+                    yield return new ParsedTokenFreeText(head);
+                }
+
+                // clear buffer as all was used
+                buffer.Clear();
+
+                yield return stopWord;
+
+                if (this.controlTokenAction is not null)
+                {
+                    ParseAction action = this.controlTokenAction(new ParsedReadState(buffer, stopWord));
+
+                    switch (action.Type)
+                    {
+                        case ParseActionType.Continue:
+                            inControlSequence = false;
+                            stopWord = null;
+                            break;
+                        case ParseActionType.ReadMoreControl:
+                            inControlSequence = true;
+                            break;
+                        case ParseActionType.YieldControl:
+                            yield return new ParsedTokenControl(string.Empty);
+                            break;
+                        case ParseActionType.YieldFreeText:
+                            yield return new ParsedTokenFreeText(string.Empty);
+                            break;
+                        case ParseActionType.ContinueWithControllUntil:
+                            inControlSequence = true;
+                            numberOfCharactersToRead = action.NumberOfCharactersToRead;
+                            break;
+                        default:
+                            throw new NotSupportedException(
+                                    $"BUG: Parse action type {action.Type} is not implemented.");
+                    }
+                }
+            }
+        }
+
+        // flush remaining buffer
+        if (buffer.Count > 0)
+        {
+            string tokenValue = new(buffer.ToArray());
+            buffer.Clear();
+
+            if (inControlSequence)
+            {
+                yield return new ParsedTokenControl(
+                        tokenValue,
+                        incompleteRead: true);
+            }
+            else
+            {
+                yield return new ParsedTokenFreeText(tokenValue);
+            }
+        }
+        else if (inControlSequence)
+        {
+            yield return new ParsedTokenControl(
+                    string.Empty,
+                    incompleteRead: true);
+        }
+    }
+
+    /// <summary>
+    /// Tries to extract this instance defined stop word
+    /// from the end of <paramref name="buffer"/>.
+    /// </summary>
+    /// <param name="buffer">Buffer to use.</param>
+    /// <param name="stopWord">Extracted stop word.</param>
+    /// <returns><see langword="true"/> if stop word was present
+    ///     at the end of <paramref name="buffer"/>;
+    ///     <see langword="false"/> otherwise.</returns>
+    private bool TryGetStopWord(
+            IReadOnlyList<char> buffer,
+            [NotNullWhen(returnValue: true)] out ParsedTokenStopWord? stopWord)
+    {
+        stopWord = default;
+
+        // return fast if not enough data
+        if (buffer.Count < this.shortestStopWord || buffer.Count == 0)
+        {
+            return false;
+        }
+
+        string lastSample = string.Empty;
+
+        foreach (ParsedTokenStopWord word in this.stopWords)
+        {
+            int take = word.Length;
+
+            if (buffer.Count < take)
+            {
+                continue;
+            }
+
+            string sample = lastSample.Length == take
+                    ? lastSample
+                    : new(buffer.Skip(buffer.Count - take).ToArray());
+
+            if (word.Value == sample)
+            {
+                stopWord = word;
+
+                return true;
+            }
+
+            lastSample = sample;
+        }
+
+        return false;
+    }
+}

--- a/src/Radicle.Common/src/TransparentProgress.cs
+++ b/src/Radicle.Common/src/TransparentProgress.cs
@@ -1,0 +1,38 @@
+﻿namespace Radicle.Common;
+
+using System;
+
+/// <summary>
+/// Mutable implementation of <see cref="IProgress{T}"/>
+/// which allows external inspection so it is not closed
+/// and can be used by other code and not only original owner.
+/// </summary>
+/// <remarks>This class is open of inheritance as it may
+/// be usefull in APIs.</remarks>
+/// <typeparam name="T">Type of the counter.</typeparam>
+public class TransparentProgress<T> : IProgress<T>
+    where T : struct
+{
+    /// <summary>
+    /// Gets UTC based start date of this progress
+    /// this is by default set to creation time of this object.
+    /// </summary>
+    public DateTime StartDate { get; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// Gets current count, this is value
+    /// normally set by <see cref="Report(T)"/>.
+    /// </summary>
+    public T Count { get; private set; }
+
+    /// <summary>
+    /// Gets or sets total count is available.
+    /// </summary>
+    public T? Total { get; set; }
+
+    /// <inheritdoc/>
+    public void Report(T value)
+    {
+        this.Count = value;
+    }
+}

--- a/src/Radicle.Common/tests/Radicle.Common.Tests/Check/Models/StringParamTest.cs
+++ b/src/Radicle.Common/tests/Radicle.Common.Tests/Check/Models/StringParamTest.cs
@@ -108,6 +108,41 @@ public class StringParamTest
     }
 
     [Theory]
+    [InlineData("foo")]
+    [InlineData("")]
+    [InlineData("foo bar")]
+    [InlineData("foo\tbar")]
+    [InlineData(" foo\tbar ")]
+    public void NoNewLines_ValidParam_Works(string input)
+    {
+        Ensure.Param(input).NoNewLines();
+    }
+
+    [Theory]
+    [InlineData("\n")]
+    [InlineData("\r")]
+    [InlineData("\n\r")]
+    [InlineData("\r\n")]
+    [InlineData("foo\n")]
+    [InlineData("foo\r")]
+    [InlineData("foo\n\r")]
+    [InlineData("foo\r\n")]
+    [InlineData("\nbar")]
+    [InlineData("\rbar")]
+    [InlineData("\n\rbar")]
+    [InlineData("\r\nbar")]
+    public void NoNewLines_InvalidParam_Throws(string input)
+    {
+        ArgumentException exc = Assert.Throws<ArgumentException>(
+                () => Ensure.Param(input).NoNewLines());
+
+        Assert.StartsWith(
+                $"Parameter 'input' with value: '{input}' cannot be a string with new lines.",
+                exc.Message,
+                StringComparison.Ordinal);
+    }
+
+    [Theory]
     [InlineData("ham", 2, 4, true, true)]
     [InlineData("em", 2, 4, true, false)]
     [InlineData("buzz", 2, 4, false, true)]

--- a/src/Radicle.Common/tests/Radicle.Common.Tests/Check/TypedNameSpecIETFLanguageTagLikeTest.cs
+++ b/src/Radicle.Common/tests/Radicle.Common.Tests/Check/TypedNameSpecIETFLanguageTagLikeTest.cs
@@ -1,7 +1,7 @@
 ﻿namespace Radicle.Common.Check;
 
-using Xunit;
 using Radicle.Common.Extensions;
+using Xunit;
 
 public class TypedNameSpecIETFLanguageTagLikeTest
 {

--- a/src/Radicle.Common/tests/Radicle.Common.Tests/Extensions/DateTimeExtensionsTest.cs
+++ b/src/Radicle.Common/tests/Radicle.Common.Tests/Extensions/DateTimeExtensionsTest.cs
@@ -1,0 +1,99 @@
+namespace Radicle.Common.Extensions;
+
+using System;
+using Xunit;
+
+public class DateTimeExtensionsTest
+{
+    [Fact]
+    public void IsOlderThan_ZeroDuration_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+                () => DateTime.UtcNow.IsOlderThan(TimeSpan.Zero));
+    }
+
+    [Fact]
+    public void IsOlderThan_NonUTC_Throws()
+    {
+        Assert.Throws<ArgumentException>(
+                () => new DateTime(1000_000, DateTimeKind.Local).IsOlderThan(TimeSpan.Zero));
+    }
+
+    [Fact]
+    public void IsOlderThan_NegativeDuration_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+                () => DateTime.UtcNow.IsOlderThan(TimeSpan.FromMinutes(-1.0)));
+    }
+
+    [Fact]
+    public void IsOlderThan_ZeroDurationOffset_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+                () => DateTimeOffset.UtcNow.IsOlderThan(TimeSpan.Zero));
+    }
+
+    [Fact]
+    public void IsOlderThan_NegativeDurationOffset_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+                () => DateTimeOffset.UtcNow.IsOlderThan(TimeSpan.FromMinutes(-1.0)));
+    }
+
+    [Fact]
+    public void IsOlderThan_OldDateTime_ReturnsTrue()
+    {
+        DateTime old = DateTime.UtcNow.Subtract(TimeSpan.FromDays(1));
+
+        Assert.True(old.IsOlderThan(TimeSpan.FromMinutes(1)));
+    }
+
+    [Fact]
+    public void IsOlderThan_RecentDateTime_ReturnsFalse()
+    {
+        DateTime old = DateTime.UtcNow.Subtract(TimeSpan.FromMinutes(1));
+
+        Assert.False(old.IsOlderThan(TimeSpan.FromDays(1)));
+    }
+
+    [Fact]
+    public void IsOlderThan_OldDateTimeOffset_ReturnsTrue()
+    {
+        DateTimeOffset old = DateTimeOffset.Now.Subtract(TimeSpan.FromDays(1));
+
+        Assert.True(old.IsOlderThan(TimeSpan.FromMinutes(1)));
+    }
+
+    [Fact]
+    public void IsOlderThan_RecentDateTimeOffset_ReturnsFalse()
+    {
+        DateTimeOffset old = DateTimeOffset.Now.Subtract(TimeSpan.FromMinutes(1));
+
+        Assert.False(old.IsOlderThan(TimeSpan.FromDays(1)));
+    }
+
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(-1.0)]
+    [InlineData(+1.0)]
+    [InlineData(+4.5)]
+    [InlineData(9)]
+    [InlineData(-10)]
+    [InlineData(-13.0)]
+    [InlineData(-14.0)]
+    [InlineData(14.0)]
+    public void IsOlderThan_DateTimeOffsetWithZone_Works(double offset)
+    {
+        DateTimeOffset date = DateTimeOffset.UtcNow
+                .Subtract(TimeSpan.FromMinutes(5))
+                .ToOffset(TimeSpan.FromHours(offset));
+
+        Assert.True(date.IsOlderThan(TimeSpan.FromSeconds(3)));
+        Assert.False(date.IsOlderThan(TimeSpan.FromHours(3)));
+
+        date = date.AddDays(1); // test also future dates
+
+        Assert.False(date.IsOlderThan(TimeSpan.FromSeconds(3)));
+        Assert.False(date.IsOlderThan(TimeSpan.FromHours(3)));
+    }
+}

--- a/src/Radicle.Common/tests/Radicle.Common.Tests/Extensions/TimeSpanExtensionsTest.cs
+++ b/src/Radicle.Common/tests/Radicle.Common.Tests/Extensions/TimeSpanExtensionsTest.cs
@@ -1,0 +1,219 @@
+namespace Radicle.Common.Extensions;
+
+using System;
+using Xunit;
+
+public class TimeSpanExtensionsTest
+{
+    [Fact]
+    public void UseIfShorterOr_ShorterThis_ReturnsThis()
+    {
+        TimeSpan one = TimeSpan.FromSeconds(2);
+        TimeSpan alternative = TimeSpan.FromSeconds(20);
+
+        Assert.Equal(one, one.UseIfShorterOr(alternative));
+    }
+
+    [Fact]
+    public void UseIfShorterOr_ShorterAlternative_ReturnsAlternative()
+    {
+        TimeSpan one = TimeSpan.FromSeconds(20);
+        TimeSpan alternative = TimeSpan.FromSeconds(-2);
+
+        Assert.Equal(alternative, one.UseIfShorterOr(alternative));
+    }
+
+    [Fact]
+    public void UseIfLongerOr_LongerThis_ReturnsThis()
+    {
+        TimeSpan one = TimeSpan.FromSeconds(-2);
+        TimeSpan alternative = TimeSpan.FromSeconds(-20);
+
+        Assert.Equal(one, one.UseIfLongerOr(alternative));
+    }
+
+    [Fact]
+    public void UseIfLongerOr_LongerAlternative_ReturnsAlternative()
+    {
+        TimeSpan one = TimeSpan.FromSeconds(-20);
+        TimeSpan other = TimeSpan.FromSeconds(20);
+
+        Assert.Equal(other, one.UseIfLongerOr(other));
+    }
+
+    [Theory]
+    [InlineData("01:14:05.93", 0, 1, 14, 5, 929)]
+    [InlineData("01:14:05.03", 0, 1, 14, 5, 26)]
+    [InlineData("12d 01:14:15.93", 12, 1, 14, 15, 929)]
+    [InlineData("12d 01:14:15.00", 12, 1, 14, 15, 0)]
+    [InlineData("-01:14:05.93", 0, -1, -14, -5, -926)]
+    [InlineData("-01:14:05.03", 0, -1, -14, -5, -26)]
+    [InlineData("-12d 01:14:15.93", -12, -1, -14, -15, -929)]
+    [InlineData("-12d 01:14:15.00", -12, -1, -14, -15, 0)]
+    public void ToCounter_ValidInput_Works(
+            string expected,
+            int d,
+            int h,
+            int m,
+            int s,
+            int ms)
+    {
+        Assert.Equal(expected, new TimeSpan(d, h, m, s, ms).ToCounter());
+    }
+
+    [Fact]
+    public void ToCounter_OutOfBoudsPrecission_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+                TimeSpan.FromMilliseconds(1234).ToCounter(secondsFloatingPrecission: 4));
+    }
+
+    [Theory]
+    [InlineData("00:00:01", 929, 0)]
+    [InlineData("00:00:00.9", 929, 1)]
+    [InlineData("00:00:00.93", 929, 2)]
+    [InlineData("00:00:00.929", 929, 3)]
+    public void ToCounter_VariablePrecission_Works(
+            string expected,
+            int ms,
+            byte precission)
+    {
+        Assert.Equal(
+                expected,
+                TimeSpan.FromMilliseconds(ms).ToCounter(secondsFloatingPrecission: precission));
+    }
+
+    [Fact]
+    public void ToH_MaxInput_Returns()
+    {
+        Assert.Equal("\u221E", TimeSpan.MaxValue.ToH());
+    }
+
+    [Fact]
+    public void ToH_MinInput_Returns()
+    {
+        Assert.Equal("-\u221E", TimeSpan.MinValue.ToH());
+    }
+
+    [Theory]
+    [InlineData("100ns", 0, 0, 0, 0.000_000_1)]
+    [InlineData("2\u03bcs", 0, 0, 0, 0.000_002)]
+    [InlineData("2s", 0, 0, 0, 2.0)]
+    [InlineData("52s", 0, 0, 0, 51.500)]
+    [InlineData("5m", 0, 0, 5, 14.0)]
+    [InlineData("90s", 0, 0, 1, 30.0)]
+    [InlineData("14m", 0, 0, 14, 15.0)]
+    [InlineData("5h", 0, 5, 14, 15.0)]
+    [InlineData("90m", 0, 1, 30, 0.0)]
+    [InlineData("7h", 0, 7, 14, 15.0)]
+    [InlineData("5d", 4, 14, 45, 9.0)]
+    [InlineData("37h", 1, 12, 45, 9.0)]
+    [InlineData("514d", 514, 0, 0, 0.0)]
+    [InlineData("2y", 780, 23, 0, 0.0)]
+    [InlineData("416d", 415, 23, 0, 0.0)]
+    [InlineData("10y", 3650, 0, 0, 0.0)]
+    [InlineData("-100ns", 0, 0, 0, -0.000_000_1)]
+    [InlineData("-2\u03bcs", 0, 0, 0, -0.000_002)]
+    [InlineData("-2s", 0, 0, 0, -2.0)]
+    [InlineData("-32s", 0, 0, 0, -31.500)]
+    [InlineData("-5m", 0, 0, -5, -14.0)]
+    [InlineData("-90s", 0, 0, -1, -30.0)]
+    [InlineData("-14m", 0, 0, -14, -15.0)]
+    [InlineData("-90m", 0, -1, -30, 0.0)]
+    [InlineData("-7h", 0, -7, -14, -15.0)]
+    [InlineData("-5d", -4, -14, -45, -9.0)]
+    [InlineData("-37h", -1, -12, -45, -9.0)]
+    [InlineData("-314d", -314, 0, 0, 0.0)]
+    [InlineData("-2y", -780, -23, 0, 0.0)]
+    [InlineData("-416d", -415, -23, 0, 0.0)]
+    [InlineData("-2y", -730, -23, 0, 0.0)]
+    [InlineData("-10y", -3650, 0, 0, 0.0)]
+    public void ToH_ValidInput_Works(
+            string expected,
+            int d,
+            int h,
+            int m,
+            double s)
+    {
+        long ticks = (TimeSpan.TicksPerDay * d)
+                + (TimeSpan.TicksPerHour * h)
+                + (TimeSpan.TicksPerMinute * m)
+                + ((long)Math.Round(TimeSpan.TicksPerSecond * s, MidpointRounding.AwayFromZero));
+
+        Assert.Equal(expected, new TimeSpan(ticks).ToH());
+    }
+
+    [Theory]
+    [InlineData("100 nanoseconds", 0, 0, 0, 0.000_000_1)]
+    [InlineData("2 microseconds", 0, 0, 0, 0.000_002)]
+    [InlineData("2 milliseconds", 0, 0, 0, 0.002)]
+    [InlineData("500 microseconds", 0, 0, 0, 0.000_500)]
+    [InlineData("515 milliseconds", 0, 0, 0, 0.514_5)]
+    [InlineData("2 seconds", 0, 0, 0, 2.0)]
+    [InlineData("52 seconds", 0, 0, 0, 51.500)]
+    [InlineData("5 minutes and 14 seconds", 0, 0, 5, 14.0)]
+    [InlineData("2 minutes and 30 seconds", 0, 0, 2, 30.0)]
+    [InlineData("5 minutes and 1 second", 0, 0, 5, 1.0)]
+    [InlineData("14 minutes and 15 seconds", 0, 0, 14, 15.0)]
+    [InlineData("5 hours and 14 minutes", 0, 5, 14, 15.0)]
+    [InlineData("90 minutes", 0, 1, 30, 0.0)]
+    [InlineData("5 hours and 1 minute", 0, 5, 1, 0.0)]
+    [InlineData("7 hours and 14 minutes", 0, 7, 14, 15.0)]
+    [InlineData("5 days and 15 hours", 5, 14, 45, 9.0)]
+    [InlineData("1 day and 15 hours", 1, 14, 45, 9.0)]
+    [InlineData("5 days and 1 hour", 5, 0, 45, 9.0)]
+    [InlineData("1 year and 149 days", 514, 0, 0, 0.0)]
+    [InlineData("2 years and 51 days", 780, 23, 0, 0.0)]
+    [InlineData("1 year and 51 days", 415, 23, 0, 0.0)]
+    [InlineData("2 years and 1 day", 730, 24, 0, 0.0)]
+    [InlineData("10 years", 3650, 0, 0, 0.0)]
+    [InlineData("-100 nanoseconds", 0, 0, 0, -0.000_000_1)]
+    [InlineData("-2 microseconds", 0, 0, 0, -0.000_002)]
+    [InlineData("-2 milliseconds", 0, 0, 0, -0.002)]
+    [InlineData("-500 microseconds", 0, 0, 0, -0.000_500)]
+    [InlineData("-515 milliseconds", 0, 0, 0, -0.514_5)]
+    [InlineData("-2 seconds", 0, 0, 0, -2.0)]
+    [InlineData("-32 seconds", 0, 0, 0, -31.500)]
+    [InlineData("-5 minutes and 14 seconds", 0, 0, -5, -14.0)]
+    [InlineData("-90 seconds", 0, 0, -1, -30.0)]
+    [InlineData("-5 minutes and 1 second", 0, 0, -5, -1.0)]
+    [InlineData("-14 minutes and 15 seconds", 0, 0, -14, -15.0)]
+    [InlineData("-5 hours and 14 minutes", 0, -5, -14, -15.0)]
+    [InlineData("-90 minutes", 0, -1, -30, 0.0)]
+    [InlineData("-5 hours and 1 minute", 0, -5, -1, 0.0)]
+    [InlineData("-7 hours and 14 minutes", 0, -7, -14, -15.0)]
+    [InlineData("-5 days and 15 hours", -5, -14, -45, -9.0)]
+    [InlineData("-1 day and 15 hours", -1, -14, -45, -9.0)]
+    [InlineData("-5 days and 1 hour", -5, 0, -45, -9.0)]
+    [InlineData("-314 days", -314, 0, 0, 0.0)]
+    [InlineData("-2 years and 51 days", -780, -23, 0, 0.0)]
+    [InlineData("-1 year and 51 days", -415, -23, 0, 0.0)]
+    [InlineData("-2 years and 1 day", -730, -24, 0, 0.0)]
+    [InlineData("-10 years", -3650, 0, 0, 0.0)]
+    public void ToHuman_ValidInput_Works(
+            string expected,
+            int d,
+            int h,
+            int m,
+            double s)
+    {
+        long ticks = (TimeSpan.TicksPerDay * d)
+                + (TimeSpan.TicksPerHour * h)
+                + (TimeSpan.TicksPerMinute * m)
+                + ((long)Math.Round(TimeSpan.TicksPerSecond * s, MidpointRounding.AwayFromZero));
+
+        Assert.Equal(expected, new TimeSpan(ticks).ToHuman());
+    }
+
+    [Fact]
+    public void ToHuman_MaxInput_Returns()
+    {
+        Assert.Equal("+\u221E", TimeSpan.MaxValue.ToHuman());
+    }
+
+    [Fact]
+    public void ToHuman_MinInput_Returns()
+    {
+        Assert.Equal("-\u221E", TimeSpan.MinValue.ToHuman());
+    }
+}

--- a/src/Radicle.Common/tests/Radicle.Common.Tests/Radicle.Common.Tests.csproj
+++ b/src/Radicle.Common/tests/Radicle.Common.Tests/Radicle.Common.Tests.csproj
@@ -7,9 +7,9 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-        <PackageReference Include="Moq" Version="4.17.2" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="Moq" Version="4.18.2" />
+        <PackageReference Include="xunit" Version="2.4.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
@@ -17,11 +17,11 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.354">
+        <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Roslynator.Analyzers" Version="4.1.0">
+        <PackageReference Include="Roslynator.Analyzers" Version="4.1.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/Radicle.Common/tests/Radicle.Common.Tests/Tokenization/CLILikeArgumentsTokenizerTest.cs
+++ b/src/Radicle.Common/tests/Radicle.Common.Tests/Tokenization/CLILikeArgumentsTokenizerTest.cs
@@ -1,0 +1,102 @@
+namespace Radicle.Common.Tokenization;
+
+using System;
+using System.Linq;
+using Radicle.Common.Tokenization.Models;
+using Xunit;
+
+public class CLILikeArgumentsTokenizerTest
+{
+    [Fact]
+    public void Parse_WithNullInput_Fails()
+    {
+        CLILikeArgumentsTokenizer t = new();
+
+        Assert.Throws<ArgumentNullException>(() => t.Parse(null!).ToArray());
+    }
+
+    [Fact]
+    public void Parse_WithEmptyInput_YieldsEmpty()
+    {
+        CLILikeArgumentsTokenizer t = new();
+
+        Assert.Empty(t.Parse(string.Empty));
+    }
+
+    [Fact]
+    public void Parse_WithEmptyTokenInput_YieldsEmpty()
+    {
+        CLILikeArgumentsTokenizer t = new();
+
+        Assert.Empty(t.Parse(" "));
+    }
+
+    [Theory]
+    [InlineData("a", "a")]
+    [InlineData("a\"\\\"\"b", "a\"b")]
+    [InlineData("a\" \"b", "a b")]
+    [InlineData("a\"\\t\"b", "a\tb")]
+    public void Parse_WithSingleStringToken_YieldsInput(string input, string expected)
+    {
+        CLILikeArgumentsTokenizer t = new();
+
+        TokenWithValue[] decoded = t.Parse(input).ToArray();
+
+        Assert.Single(decoded);
+        TokenString ds = Assert.IsType<TokenString>(decoded[0]);
+        Assert.Equal(expected, ds.StringValue);
+    }
+
+    [Theory]
+    [InlineData("a b", "a", "b")]
+    [InlineData("a\tb", "a", "b")]
+    [InlineData("a\nb", "a", "b")]
+    [InlineData("a\rb", "a", "b")]
+    [InlineData("a\fb", "a", "b")]
+    [InlineData("a\vb", "a", "b")]
+    [InlineData("foo   bar", "foo", "bar")]
+    [InlineData("  foo bar", "foo", "bar")]
+    [InlineData("foo bar  ", "foo", "bar")]
+    [InlineData("a\"\\\"\"b \" \"", "a\"b", " ")]
+    public void Parse_WithTwoStringTokens_YieldsInput(string input, string expected1, string expected2)
+    {
+        CLILikeArgumentsTokenizer t = new();
+
+        TokenWithValue[] decoded = t.Parse(input).ToArray();
+
+        Assert.Equal(2, decoded.Length);
+
+        TokenString ds1 = Assert.IsType<TokenString>(decoded[0]);
+        Assert.Equal(expected1, ds1.StringValue);
+
+        TokenString ds2 = Assert.IsType<TokenString>(decoded[1]);
+        Assert.Equal(expected2, ds2.StringValue);
+    }
+
+    [Theory]
+    [InlineData(" foo\n", 1)]
+    [InlineData("a\"\\\"\"b", 1)]
+    [InlineData("a b c d e", 5)]
+    [InlineData(" a \"b c d\" e ", 3)]
+    [InlineData(" \"\" \"\"\"\" \"\" ", 3)]
+    public void Parse_WithMultipleStringTokens_YieldsInput(string input, int tokenCount)
+    {
+        CLILikeArgumentsTokenizer t = new();
+
+        TokenWithValue[] decoded = t.Parse(input).ToArray();
+
+        Assert.Equal(tokenCount, decoded.Length);
+    }
+
+    [Fact]
+    public void Parse_WithSingleBinaryToken_YieldsInput()
+    {
+        CLILikeArgumentsTokenizer t = new();
+
+        TokenWithValue[] decoded = t.Parse("\"\\x00\"").ToArray();
+
+        Assert.Single(decoded);
+        TokenBinary tokenWithBinary = Assert.IsType<TokenBinary>(decoded[0]);
+        Assert.Equal(new byte[] { 0 }, tokenWithBinary.Bytes.ToArray());
+    }
+}

--- a/src/Radicle.Common/tests/Radicle.Common.Tests/Tokenization/CLikeStringLiteralDefinitionTest.cs
+++ b/src/Radicle.Common/tests/Radicle.Common.Tests/Tokenization/CLikeStringLiteralDefinitionTest.cs
@@ -1,0 +1,465 @@
+namespace Radicle.Common.Tokenization;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Radicle.Common.Tokenization.Models;
+using Xunit;
+
+public class CLikeStringLiteralDefinitionTest
+{
+    public static IEnumerable<object[]> BinaryRawValueCasesForMinimal => new List<object[]>
+    {
+        new object[] { Array.Empty<byte>(), string.Empty },
+        new object[] { new byte[] { (byte)'\n', (byte)'\r', (byte)'\t', (byte)'\b', (byte)'\a', (byte)'\f', (byte)'\v' }, "\n\r\t\b\a\f\v" },
+        new object[] { new byte[] { (byte)'"', (byte)'\'', (byte)'\\' }, "\\\"'\\\\" },
+        new object[] { new byte[] { 0xc3, 0xb4 }, "\\xc3\\xb4" }, // letter
+    };
+
+    public static IEnumerable<object[]> BinaryRawValueCasesForNormal => new List<object[]>
+    {
+        new object[] { Array.Empty<byte>(), string.Empty },
+        new object[] { new byte[] { (byte)'\n', (byte)'\r', (byte)'\t', (byte)'\b', (byte)'\a', (byte)'\f', (byte)'\v' }, "\\n\\r\\t\\b\\a\\f\\v" },
+        new object[] { new byte[] { (byte)'"', (byte)'\'', (byte)'\\' }, "\\\"'\\\\" },
+        new object[] { new byte[] { 0xc3, 0xb4 }, "\\xc3\\xb4" }, // letter
+    };
+
+    public static IEnumerable<object[]> BinaryRawValueCasesForConservative => new List<object[]>
+    {
+        new object[] { Array.Empty<byte>(), string.Empty },
+        new object[] { new byte[] { (byte)'\n', (byte)'\r', (byte)'\t', (byte)'\b', (byte)'\a', (byte)'\f', (byte)'\v' }, "\\n\\r\\t\\b\\a\\f\\v" },
+        new object[] { new byte[] { (byte)'"', (byte)'\'', (byte)'\\' }, "\\\"'\\\\" },
+        new object[] { new byte[] { 0xc3, 0xb4 }, "\\xc3\\xb4" }, // letter
+    };
+
+    [Fact]
+    public void Encode_NullInput_Throws()
+    {
+        CLikeStringLiteralDefinition def = new();
+
+        Assert.Throws<ArgumentNullException>(() => def.Encode(null!));
+    }
+
+    [Theory]
+    [InlineData("", "")]
+    [InlineData("a", "a")]
+    [InlineData("\n\r\t\b\a\f\v", "\n\r\t\b\a\f\v")]
+    [InlineData("\"'\\", "\\\"'\\\\")]
+    [InlineData("\u00f4", "\u00f4")] // letter
+    [InlineData("\u00bb", "\u00bb")] // punctuation
+    [InlineData("\u2601\uFE0F", "\\xe2\\x98\\x81\\xef\\xb8\\x8f")] // emoji
+    public void Encode_StringInputWithMinimalSetup_Works(
+            string rawInput,
+            string expectedEncoded)
+    {
+        CLikeStringLiteralDefinition def = CLikeStringLiteralDefinition.Minimal;
+
+        Assert.Equal(expectedEncoded, def.Encode(rawInput));
+    }
+
+    [Theory]
+    [InlineData("", "")]
+    [InlineData("a", "a")]
+    [InlineData("\n\r\t\b\a\f\v", "\\n\\r\\t\\b\\a\\f\\v")]
+    [InlineData("\"'\\", "\\\"'\\\\")]
+    [InlineData("\u00f4", "\u00f4")] // letter
+    [InlineData("\u00bb", "\u00bb")] // punctuation
+    [InlineData("\u2601\uFE0F", "\\xe2\\x98\\x81\\xef\\xb8\\x8f")] // emoji
+    public void Encode_StringInputWithNormalSetup_Works(
+            string rawInput,
+            string expectedEncoded)
+    {
+        CLikeStringLiteralDefinition def = CLikeStringLiteralDefinition.Normal;
+
+        Assert.Equal(expectedEncoded, def.Encode(rawInput));
+    }
+
+    [Theory]
+    [InlineData("", "")]
+    [InlineData("a", "a")]
+    [InlineData("\n\r\t\b\a\f\v", "\\n\\r\\t\\b\\a\\f\\v")]
+    [InlineData("\"'\\", "\\\"'\\\\")]
+    [InlineData("\u00f4", "\\xc3\\xb4")] // letter
+    [InlineData("\u00bb", "\\xc2\\xbb")] // punctuation
+    [InlineData("\u2601\uFE0F", "\\xe2\\x98\\x81\\xef\\xb8\\x8f")] // emoji
+    public void Encode_StringInputWithConservativeSetup_Works(
+            string rawInput,
+            string expectedEncoded)
+    {
+        CLikeStringLiteralDefinition def = CLikeStringLiteralDefinition.Conservative;
+
+        Assert.Equal(expectedEncoded, def.Encode(rawInput));
+    }
+
+    [Theory]
+    [MemberData(nameof(BinaryRawValueCasesForMinimal))]
+    public void Encode_BinaryInputWithMinimalSetup_Works(
+            byte[] rawInput,
+            string expectedEncoded)
+    {
+        CLikeStringLiteralDefinition def = CLikeStringLiteralDefinition.Minimal;
+
+        Assert.Equal(expectedEncoded, def.Encode(rawInput));
+    }
+
+    [Theory]
+    [MemberData(nameof(BinaryRawValueCasesForNormal))]
+    public void Encode_BinaryInputWithNormalSetup_Works(
+            byte[] rawInput,
+            string expectedEncoded)
+    {
+        CLikeStringLiteralDefinition def = CLikeStringLiteralDefinition.Normal;
+
+        Assert.Equal(expectedEncoded, def.Encode(rawInput));
+    }
+
+    [Theory]
+    [MemberData(nameof(BinaryRawValueCasesForConservative))]
+    public void Encode_BinaryInputWithConservativeSetup_Works(
+            byte[] rawInput,
+            string expectedEncoded)
+    {
+        CLikeStringLiteralDefinition def = CLikeStringLiteralDefinition.Conservative;
+
+        Assert.Equal(expectedEncoded, def.Encode(rawInput));
+    }
+
+    [Fact]
+    public void GetLiteral_NullInput_Throws()
+    {
+        CLikeStringLiteralDefinition def = new();
+
+        Assert.Throws<ArgumentNullException>(() => def.GetLiteral(null!));
+    }
+
+    [Theory]
+    [InlineData("", "\"\"")]
+    [InlineData("a", "\"a\"")]
+    [InlineData("\n\r\t\b\a\f\v", "\"\n\r\t\b\a\f\v\"")]
+    [InlineData("\"'\\", "\"\\\"'\\\\\"")]
+    [InlineData("\u00f4", "\"\u00f4\"")] // letter
+    [InlineData("\u00bb", "\"\u00bb\"")] // punctuation
+    [InlineData("\u2601\uFE0F", "\"\\xe2\\x98\\x81\\xef\\xb8\\x8f\"")] // emoji
+    public void GetLiteral_StringInputWithMinimalSetup_Works(
+            string rawInput,
+            string expectedEncoded)
+    {
+        CLikeStringLiteralDefinition def = CLikeStringLiteralDefinition.Minimal;
+
+        Assert.Equal(expectedEncoded, def.GetLiteral(rawInput));
+    }
+
+    [Theory]
+    [InlineData("", "\"\"")]
+    [InlineData("a", "\"a\"")]
+    [InlineData("\n\r\t\b\a\f\v", "\"\\n\\r\\t\\b\\a\\f\\v\"")]
+    [InlineData("\"'\\", "\"\\\"'\\\\\"")]
+    [InlineData("\u00f4", "\"\u00f4\"")] // letter
+    [InlineData("\u00bb", "\"\u00bb\"")] // punctuation
+    [InlineData("\u2601\uFE0F", "\"\\xe2\\x98\\x81\\xef\\xb8\\x8f\"")] // emoji
+    public void GetLiteral_StringInputWithNormalSetup_Works(
+            string rawInput,
+            string expectedEncoded)
+    {
+        CLikeStringLiteralDefinition def = CLikeStringLiteralDefinition.Normal;
+
+        Assert.Equal(expectedEncoded, def.GetLiteral(rawInput));
+    }
+
+    [Theory]
+    [InlineData("", "\"\"")]
+    [InlineData("a", "\"a\"")]
+    [InlineData("\n\r\t\b\a\f\v", "\"\\n\\r\\t\\b\\a\\f\\v\"")]
+    [InlineData("\"'\\", "\"\\\"'\\\\\"")]
+    [InlineData("\u00f4", "\"\\xc3\\xb4\"")] // letter
+    [InlineData("\u00bb", "\"\\xc2\\xbb\"")] // punctuation
+    [InlineData("\u2601\uFE0F", "\"\\xe2\\x98\\x81\\xef\\xb8\\x8f\"")] // emoji
+    public void GetLiteral_StringInputWithConservativeSetup_Works(
+            string rawInput,
+            string expectedEncoded)
+    {
+        CLikeStringLiteralDefinition def = CLikeStringLiteralDefinition.Conservative;
+
+        Assert.Equal(expectedEncoded, def.GetLiteral(rawInput));
+    }
+
+    [Theory]
+    [MemberData(nameof(BinaryRawValueCasesForMinimal))]
+    public void GetLiteral_BinaryInputWithMinimalSetup_Works(
+            byte[] rawInput,
+            string expectedEncoded)
+    {
+        CLikeStringLiteralDefinition def = CLikeStringLiteralDefinition.Minimal;
+
+        Assert.Equal($"\"{expectedEncoded}\"", def.GetLiteral(rawInput));
+    }
+
+    [Theory]
+    [MemberData(nameof(BinaryRawValueCasesForNormal))]
+    public void GetLiteral_BinaryInputWithNormalSetup_Works(
+            byte[] rawInput,
+            string expectedEncoded)
+    {
+        CLikeStringLiteralDefinition def = CLikeStringLiteralDefinition.Normal;
+
+        Assert.Equal($"\"{expectedEncoded}\"", def.GetLiteral(rawInput));
+    }
+
+    [Theory]
+    [MemberData(nameof(BinaryRawValueCasesForConservative))]
+    public void GetLiteral_BinaryInputWithConservativeSetup_Works(
+            byte[] rawInput,
+            string expectedEncoded)
+    {
+        CLikeStringLiteralDefinition def = CLikeStringLiteralDefinition.Conservative;
+
+        Assert.Equal($"\"{expectedEncoded}\"", def.GetLiteral(rawInput));
+    }
+
+    [Fact]
+    public void Decode_NullInput_Throws()
+    {
+        CLikeStringLiteralDefinition def = CLikeStringLiteralDefinition.Conservative;
+
+        Assert.Throws<ArgumentNullException>(() => def.Decode(null!));
+    }
+
+    [Theory]
+    [InlineData("", "")]
+    [InlineData("a", "a")]
+    [InlineData("\n\r\t\b\a\f\v", "\\n\\r\\t\\b\\a\\f\\v")]
+    [InlineData("\"'\\", "\\\"'\\\\")]
+    public void Decode_StringClearInput_Works(
+            string expected,
+            string encodedInput)
+    {
+        CLikeStringLiteralDefinition def = CLikeStringLiteralDefinition.Conservative;
+
+        TokenMatch decoded = def.Decode(encodedInput);
+
+        TokenString decodedWithString =
+                Assert.IsType<TokenString>(decoded);
+        Assert.Equal(expected, decodedWithString.StringValue);
+    }
+
+    [Theory]
+    [InlineData("\u00f4", "\\xc3\\xb4")] // letter
+    [InlineData("\u00bb", "\\xc2\\xbb")] // punctuation
+    [InlineData("\u2601\uFE0F", "\\xe2\\x98\\x81\\xef\\xb8\\x8f")] // emoji
+    public void Decode_BinaryClearInput_Works(
+            string expectedUTF8,
+            string encodedInput)
+    {
+        CLikeStringLiteralDefinition def = CLikeStringLiteralDefinition.Conservative;
+
+        TokenMatch decoded = def.Decode(encodedInput);
+
+        TokenBinary decodedWithBytes = Assert.IsType<TokenBinary>(decoded);
+        Assert.Equal(Encoding.UTF8.GetBytes(expectedUTF8), decodedWithBytes.Bytes.ToArray());
+    }
+
+    [Fact]
+    public void Decode_InputWithDoubleQuote_ReturnsFailure()
+    {
+        CLikeStringLiteralDefinition def = CLikeStringLiteralDefinition.Conservative;
+
+        TokenMatch decoded = def.Decode("\"");
+
+        TokenFailure failure = Assert.IsType<TokenFailure>(decoded);
+        Assert.Equal("Disallowed character in encoded string literal content: \"\\\"\"", failure.FormatErrorMessage);
+    }
+
+    [Fact]
+    public void Decode_InputWithInvalidHex_ReturnsFailure()
+    {
+        CLikeStringLiteralDefinition def = CLikeStringLiteralDefinition.Conservative;
+
+        TokenMatch decoded = def.Decode("\\xgg");
+
+        TokenFailure failure = Assert.IsType<TokenFailure>(decoded);
+        Assert.Equal("Invalid escape sequence: \"xgg\"", failure.FormatErrorMessage);
+    }
+
+    [Theory]
+    [InlineData("\\")]
+    [InlineData("\\x")]
+    [InlineData("\\x0")]
+    public void Decode_IncompleteInput_ReturnsFailure(string encodedInput)
+    {
+        CLikeStringLiteralDefinition def = CLikeStringLiteralDefinition.Conservative;
+
+        TokenMatch decoded = def.Decode(encodedInput);
+
+        TokenFailure failure = Assert.IsType<TokenFailure>(decoded);
+        Assert.Equal("Unfinished string literal", failure.FormatErrorMessage);
+    }
+
+    [Fact]
+    public void TryReadStringLiteral_NullStringInput_Throws()
+    {
+        CLikeStringLiteralDefinition def = CLikeStringLiteralDefinition.Conservative;
+
+        Assert.Throws<ArgumentNullException>(() => def.TryReadStringLiteral((string)null!));
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(2)]
+    public void TryReadStringLiteral_OutOfRangeInputForString_Throws(int startAt)
+    {
+        CLikeStringLiteralDefinition def = CLikeStringLiteralDefinition.Conservative;
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => def.TryReadStringLiteral("a", startAt: startAt));
+    }
+
+    [Theory]
+    [InlineData("", 0)]
+    [InlineData("a", 1)]
+    public void TryReadStringLiteral_StartAtEndOfStringInput_ReturnsFailure(
+            string input,
+            int startAt)
+    {
+        CLikeStringLiteralDefinition def = CLikeStringLiteralDefinition.Conservative;
+
+        TokenDecoding decoded = def.TryReadStringLiteral(input, startAt: startAt);
+
+        TokenFailure failure = Assert.IsType<TokenFailure>(decoded);
+        Assert.Equal("Missing literal boundary: \"\\\"\"", failure.FormatErrorMessage);
+    }
+
+    [Theory]
+    [InlineData("", "\"\"", 0)]
+    [InlineData("a", "\"a\"", 0)]
+    [InlineData("\n\r\t\b\a\f\v", "\"\\n\\r\\t\\b\\a\\f\\v\"", 0)]
+    [InlineData("\"'\\", "\"\\\"'\\\\\"", 0)]
+    [InlineData("", "some\"\"", 4)]
+    [InlineData("", "some\"\"\"", 4)]
+    [InlineData("", "some\"\"suffix", 4)]
+    [InlineData("", "some\"\"\\xgg", 4)]
+    [InlineData("multiple", "\"multiple\"\"literals\"\"\"", 0)]
+    [InlineData("literals", "\"multiple\"\"literals\"\"\"", 10)]
+    [InlineData("", "\"multiple\"\"literals\"\"\"", 20)]
+    public void TryReadStringLiteral_StringClearInput_Works(
+            string expected,
+            string encodedLiteral,
+            int startAt)
+    {
+        CLikeStringLiteralDefinition def = CLikeStringLiteralDefinition.Conservative;
+
+        TokenDecoding decoded = def.TryReadStringLiteral(encodedLiteral, startAt: startAt);
+
+        TokenString decodedWithString =
+                Assert.IsType<TokenString>(decoded);
+        Assert.Equal(expected, decodedWithString.StringValue);
+    }
+
+    [Theory]
+    [InlineData("\u00f4", "\"\\xc3\\xb4\"", 0)] // letter
+    [InlineData("\u00bb", "\"\\xc2\\xbb\"", 0)] // punctuation
+    [InlineData("\u2601\uFE0F", "\"\\xe2\\x98\\x81\\xef\\xb8\\x8f\"", 0)] // emoji
+    [InlineData("\u00f4", "  \"\\xc3\\xb4\"", 2)] // letter
+    [InlineData("\u00f4", "  \"\\xc3\\xb4\"\"", 2)] // letter
+    [InlineData("\u00f4", "  \"\\xc3\\xb4\"\"\\xgg", 2)] // letter
+    public void TryReadStringLiteral_BinaryClearInput_Works(
+            string expectedUTF8,
+            string encodedLiteral,
+            int startAt)
+    {
+        CLikeStringLiteralDefinition def = CLikeStringLiteralDefinition.Conservative;
+
+        TokenDecoding decoded = def.TryReadStringLiteral(encodedLiteral, startAt: startAt);
+
+        TokenBinary decodedWithBytes = Assert.IsType<TokenBinary>(decoded);
+        Assert.Equal(Encoding.UTF8.GetBytes(expectedUTF8), decodedWithBytes.Bytes.ToArray());
+    }
+
+    [Fact]
+    public void TryReadStringLiteral_InputWithNoLiteral_ReturnsNoMathc()
+    {
+        CLikeStringLiteralDefinition def = CLikeStringLiteralDefinition.Conservative;
+
+        TokenDecoding decoded = def.TryReadStringLiteral("this is not a literal \"\"");
+
+        Assert.IsType<TokenNoMatch>(decoded);
+    }
+
+    [Theory]
+    [InlineData("\"\"", 0, 2)]
+    [InlineData("\"\"suffix", 0, 2)]
+    [InlineData("\"foo\"", 0, 5)]
+    [InlineData("\"foo\" \"bar\"", 6, 11)]
+    public void TryReadStringLiteral_InputWithMultipleLiterals_ReturnsContinueAt(
+            string inputLiteral,
+            int startAt,
+            int continueAt)
+    {
+        CLikeStringLiteralDefinition def = CLikeStringLiteralDefinition.Conservative;
+
+        TokenDecoding decoded = def.TryReadStringLiteral(inputLiteral, startAt: startAt);
+
+        Assert.True(decoded is TokenWithValue);
+        Assert.Equal(continueAt, ((TokenWithValue)decoded).ContinueAt);
+    }
+
+    [Fact]
+    public void TryReadStringLiteral_InputWithInvalidHex_ReturnsFailure()
+    {
+        CLikeStringLiteralDefinition def = CLikeStringLiteralDefinition.Conservative;
+
+        TokenDecoding decoded = def.TryReadStringLiteral("\"\\xgg\"");
+
+        TokenFailure failure = Assert.IsType<TokenFailure>(decoded);
+        Assert.Equal("Invalid escape sequence: \"xgg\"", failure.FormatErrorMessage);
+    }
+
+    [Theory]
+    [InlineData("\"", 0)]
+    [InlineData("\"\\", 0)]
+    [InlineData("\"\\x", 0)]
+    [InlineData("\"\\x0", 0)]
+    [InlineData("\"\"", 1)]
+    [InlineData("  \"\\x0", 2)]
+    public void TryReadStringLiteral_IncompleteInput_ReturnsFailure(
+            string encodedInput,
+            int startAt)
+    {
+        CLikeStringLiteralDefinition def = CLikeStringLiteralDefinition.Conservative;
+
+        TokenDecoding decoded = def.TryReadStringLiteral(encodedInput, startAt: startAt);
+
+        TokenFailure failure = Assert.IsType<TokenFailure>(decoded);
+        Assert.Equal("Unfinished string literal", failure.FormatErrorMessage);
+    }
+
+    [Fact]
+    public void TryReadStringLiteral_NullDecodedStringInput_Throws()
+    {
+        CLikeStringLiteralDefinition def = CLikeStringLiteralDefinition.Conservative;
+
+        Assert.Throws<ArgumentNullException>(() => def.TryReadStringLiteral((TokenString)null!));
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(2)]
+    public void TryReadStringLiteral_OutOfRangeInputForDecodedString_Throws(int startAt)
+    {
+        CLikeStringLiteralDefinition def = CLikeStringLiteralDefinition.Conservative;
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => def.TryReadStringLiteral(
+                TokenString.GetPassThrough("a"),
+                startAt: startAt));
+    }
+
+    [Fact]
+    public void TryReadStringLiteral_DecodedStringInut_ReturnsCorrectParent()
+    {
+        CLikeStringLiteralDefinition def = CLikeStringLiteralDefinition.Conservative;
+        TokenString parent = TokenString.GetPassThrough("\"foo\"");
+
+        TokenDecoding decoded = def.TryReadStringLiteral(parent);
+
+        Assert.True(ReferenceEquals(parent, decoded.Parent));
+    }
+}

--- a/src/Radicle.Common/tests/Radicle.Common.Tests/Tokenization/StopWordStringParserTest.cs
+++ b/src/Radicle.Common/tests/Radicle.Common.Tests/Tokenization/StopWordStringParserTest.cs
@@ -1,0 +1,215 @@
+namespace Radicle.Common.Tokenization;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Radicle.Common.Tokenization.Models;
+using Xunit;
+
+public class StopWordStringParserTest
+{
+    private static readonly ParsedTokenStopWord Em = new('_');
+
+    private static readonly ParsedTokenStopWord Bold = new('*');
+
+    private static readonly ParsedTokenStopWord Escape = new('\\');
+
+    [Fact]
+    public void Constructor_NullStopWords_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+                new StopWordStringParser(stopWords: new HashSet<ParsedTokenStopWord>() { null! }));
+    }
+
+    [Fact]
+    public void Parse_NullInput_Throws()
+    {
+        StopWordStringParser p = new();
+
+        Assert.Throws<ArgumentNullException>(() => p.Parse(null!).ToArray());
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(2)]
+    public void Parse_OutOfRangeStart_Throws(int startAt)
+    {
+        StopWordStringParser p = new();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => p.Parse("a", startAt: startAt).ToArray());
+    }
+
+    [Fact]
+    public void Parse_EmptyInput_YieldsEmptyCollection()
+    {
+        StopWordStringParser p = new();
+
+        Assert.Empty(p.Parse(string.Empty));
+    }
+
+    [Fact]
+    public void Parse_EndOfStringStart_YieldsEmptyCollection()
+    {
+        StopWordStringParser p = new();
+
+        Assert.Empty(p.Parse("a", startAt: 1));
+    }
+
+    [Theory]
+    [InlineData("foo")]
+    [InlineData("foo bar")]
+    [InlineData("foo bar\n\tbar foo\n")]
+    public void Parse_InputFreeText_Works(string input)
+    {
+        StopWordStringParser p = ConstructSimpleMarkdownTokenParser();
+
+        ParsedToken[] tokens = p.Parse(input).ToArray();
+
+        ParsedToken token = Assert.Single(tokens);
+        Assert.Equal(new ParsedTokenFreeText(input), token);
+    }
+
+    [Fact]
+    public void Parse_InputWithOneLeadingControl_Works()
+    {
+        StopWordStringParser p = ConstructSimpleMarkdownTokenParser();
+
+        Assert.Equal(
+            new ParsedToken[]
+            {
+                new ParsedTokenStopWord("\\"),
+                new ParsedTokenControl("*"),
+                new ParsedTokenFreeText("foo bar"),
+            },
+            p.Parse("\\*foo bar"));
+    }
+
+    [Fact]
+    public void Parse_InputWithOneControl_Works()
+    {
+        StopWordStringParser p = ConstructSimpleMarkdownTokenParser();
+
+        Assert.Equal(
+            new ParsedToken[]
+            {
+                new ParsedTokenFreeText("foo"),
+                new ParsedTokenStopWord("\\"),
+                new ParsedTokenControl("*"),
+                new ParsedTokenFreeText("bar"),
+            },
+            p.Parse("foo\\*bar"));
+    }
+
+    [Fact]
+    public void Parse_InputWithOneTrailingControl_Works()
+    {
+        StopWordStringParser p = ConstructSimpleMarkdownTokenParser();
+
+        Assert.Equal(
+            new ParsedToken[]
+            {
+                new ParsedTokenFreeText("foo bar"),
+                new ParsedTokenStopWord("\\"),
+                new ParsedTokenControl("*"),
+            },
+            p.Parse("foo bar\\*"));
+    }
+
+    [Fact]
+    public void Parse_InputWithTwoControl_Works()
+    {
+        StopWordStringParser p = ConstructSimpleMarkdownTokenParser();
+
+        Assert.Equal(
+            new ParsedToken[]
+            {
+                new ParsedTokenFreeText("foo"),
+                new ParsedTokenStopWord("\\"),
+                new ParsedTokenControl("*"),
+                new ParsedTokenFreeText("bar"),
+                new ParsedTokenStopWord("\\"),
+                new ParsedTokenControl("n"),
+            },
+            p.Parse("foo\\*bar\\n"));
+    }
+
+    [Theory]
+    [InlineData("\\")]
+    [InlineData("1")]
+    [InlineData("?")]
+    [InlineData("#")]
+    [InlineData("{")]
+    public void Parse_InputWithOneVariousControl_Works(string controlSequence)
+    {
+        StopWordStringParser p = ConstructSimpleMarkdownTokenParser();
+
+        Assert.Equal(
+            new ParsedToken[]
+            {
+                new ParsedTokenFreeText("foo"),
+                new ParsedTokenStopWord("\\"),
+                new ParsedTokenControl(controlSequence),
+                new ParsedTokenFreeText("bar"),
+            },
+            p.Parse($"foo\\{controlSequence}bar"));
+    }
+
+    [Fact]
+    public void Parse_IncompleteControl_Works()
+    {
+        StopWordStringParser p = ConstructSimpleMarkdownTokenParser();
+
+        Assert.Equal(
+            new ParsedToken[]
+            {
+                new ParsedTokenFreeText("foo"),
+                new ParsedTokenStopWord("\\"),
+                new ParsedTokenControl("*"),
+                new ParsedTokenFreeText("bar"),
+                new ParsedTokenStopWord("\\"),
+                new ParsedTokenControl(string.Empty, incompleteRead: true),
+            },
+            p.Parse("foo\\*bar\\"));
+    }
+
+    [Theory]
+    [InlineData("*")]
+    [InlineData("_")]
+    public void Parse_WithMarkdownStopWordPairInput_works(
+            string stopWord)
+    {
+        StopWordStringParser p = ConstructSimpleMarkdownTokenParser();
+
+        Assert.Equal(
+            new ParsedToken[]
+            {
+                new ParsedTokenFreeText("foo"),
+                new ParsedTokenStopWord(stopWord),
+                new ParsedTokenStopWord("\\"),
+                new ParsedTokenControl(stopWord),
+                new ParsedTokenFreeText("bar"),
+                new ParsedTokenStopWord(stopWord),
+            },
+            p.Parse($"foo{stopWord}\\{stopWord}bar{stopWord}"));
+    }
+
+    private static StopWordStringParser ConstructSimpleMarkdownTokenParser()
+    {
+        return new StopWordStringParser(
+                stopWords: new HashSet<ParsedTokenStopWord>(new[]
+                {
+                    Em,
+                    Bold,
+                    Escape,
+                }),
+                controlTokenAction: (state) =>
+                {
+                    if (state.TriggeringStopWord == Escape)
+                    {
+                        return ParseAction.ContinueWithControllUntil(1);
+                    }
+
+                    return ParseAction.Continue;
+                });
+    }
+}


### PR DESCRIPTION
- Add sample project to show capabilities of REPL CLI tooling
- Add tooling for building iteractive REPL (Read-eval-print loop) CLI (command line interface) program. Supported features include progress indicators as well as scaffold for commands. See sample projects for examples.
- Add new extensions and parsing functionality including: string parameter line check, new string and binary dumps, new time related extensions, looping collection, tokenizers and parsers, string literal functionality, support for simple markdown for CLI, better progress class.