### PR TITLE
No new line string validation and new snipped extensions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,10 @@ name: .NET
 
 on:
   push:
+    branches:
+      - '**'
+    tags-ignore:
+      - '**'
   pull_request:
     branches: [ "master" ]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,17 @@ Current list of maintained releases:
 - not supported: -
 
 
+0.5.0 (2022-10-13)
+------------------
+
+Upgrade urgency: LOW; bug fixes and new API
+
+- Fix bug preventing correct validation of long strings for no new lines
+- Clarify use of base disposable class in documentation
+- Add new Snippet end SnippetLiteral extension,
+  more suited for trimmed string value dumps than Ellipsis
+
+
 0.4.0 (2022-09-30)
 ------------------
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,7 @@
 
             PackageVersion is auto-set when packing.
         -->
-        <Version>0.4.0</Version>
+        <Version>0.5.0</Version>
         <PackageProjectUrl>https://github.com/jozefsivek/radicle.cs</PackageProjectUrl>
         <PackageReleaseNotes>https://github.com/jozefsivek/radicle.cs/blob/master/CHANGELOG.md</PackageReleaseNotes>
     </PropertyGroup>

--- a/src/Radicle.Common/src/Base/AsyncDisposable.cs
+++ b/src/Radicle.Common/src/Base/AsyncDisposable.cs
@@ -9,13 +9,21 @@ using System.Threading.Tasks;
 /// or collection.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Disposing is NOT thread safe.
 /// Read https://alistairevans.co.uk/2019/10/24/net-asynchronous-disposal-tips-for-implementing-iasyncdisposable-on-your-own-types/ ,
-/// https://docs.microsoft.com/en-us/dotnet/api/system.object.finalize?view=net-5.0
+/// https://docs.microsoft.com/en-us/dotnet/api/system.object.finalize?view=net-5.0 ,
+/// https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-disposeasync#disposeasync-and-disposeasynccore
 /// and
 /// https://docs.microsoft.com/en-us/dotnet/standard/garbage-collection/unmanaged .
 /// Important, do not stack async usings:
 /// https://docs.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-disposeasync#unacceptable-pattern .
+/// </para>
+/// <para>
+/// If you need to react to disposing follow: https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-dispose#implement-the-dispose-pattern-for-a-derived-class ,
+/// define your own dispose flag to detect repeated calls
+/// and call base <see cref="DisposeAsyncCore"/> after yours override.
+/// </para>
 /// </remarks>
 public class AsyncDisposable : Disposable, IAsyncDisposable
 {

--- a/src/Radicle.Common/src/Base/Disposable.cs
+++ b/src/Radicle.Common/src/Base/Disposable.cs
@@ -10,11 +10,18 @@ using Radicle.Common.Check;
 /// several disposable objects into one as base class or collection.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Disposing is NOT thread safe.
 /// Read https://alistairevans.co.uk/2019/10/24/net-asynchronous-disposal-tips-for-implementing-iasyncdisposable-on-your-own-types/ ,
 /// https://docs.microsoft.com/en-us/dotnet/api/system.object.finalize?view=net-5.0
 /// and
 /// https://docs.microsoft.com/en-us/dotnet/standard/garbage-collection/unmanaged .
+/// </para>
+/// <para>
+/// If you need to react to disposing follow: https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-dispose#implement-the-dispose-pattern-for-a-derived-class ,
+/// define your own dispose flag to detect repeated calls
+/// and call base <see cref="Dispose(bool)"/> after yours override.
+/// </para>
 /// </remarks>
 public class Disposable : IDisposable
 {

--- a/src/Radicle.Common/src/Check/Models/Generic/IParam.cs
+++ b/src/Radicle.Common/src/Check/Models/Generic/IParam.cs
@@ -40,7 +40,7 @@ public interface IParam<T> : IParam
         get
         {
             string val = this.Value is string s
-                    ? "'" + s.Ellipsis() + "'"
+                    ? s.SnippetLiteral()
                     : this.Value.ToString();
 
             return $"Parameter '{this.Name}' with value: {val}";

--- a/src/Radicle.Common/src/Check/Models/StringParam.cs
+++ b/src/Radicle.Common/src/Check/Models/StringParam.cs
@@ -11,6 +11,10 @@ using Radicle.Common.Check.Models.Generic;
 /// </summary>
 internal readonly struct StringParam : IStringParam
 {
+    private static readonly Regex SingleLineRegex = new(
+            TypedNameSpec.SingleLine.Pattern,
+            RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.Singleline);
+
     /// <summary>
     /// Initializes a new instance of the <see cref="StringParam"/> struct.
     /// </summary>
@@ -62,7 +66,7 @@ internal readonly struct StringParam : IStringParam
     {
         if (this.InnerParam.IsSpecified
                 && this.InnerParam.Value.Length != 0
-                && !TypedNameSpec.SingleLine.IsValid(this.InnerParam.Value))
+                && !SingleLineRegex.IsMatch(this.InnerParam.Value))
         {
             throw new ArgumentException(
                     $"{this.InnerParam.DescriptionWithValue} cannot be a string with new lines.",

--- a/src/Radicle.Common/src/Extensions/StringExtensions.cs
+++ b/src/Radicle.Common/src/Extensions/StringExtensions.cs
@@ -1,19 +1,32 @@
 namespace Radicle.Common.Extensions;
 
 using System;
+using System.Globalization;
 using Radicle.Common.Check;
+using Radicle.Common.Tokenization;
 
 /// <summary>
 /// Extensions for <see cref="string"/>.
 /// </summary>
 public static class StringExtensions
 {
+    private const string OmissionStart = "[+";
+    private const string OmissionEnd = " more]";
+    private const string OmissionEndShort = "]";
+    private const string OmissionEllipsisSuffix = "[+]";
+
+    private static readonly (string Start, string Stop)[] OmissionAttempts = new[]
+    {
+        (OmissionStart, OmissionEnd),
+        (OmissionStart, OmissionEndShort),
+    };
+
     /// <summary>
-    /// Convert given <paramref name="str"/>
+    /// Convert given <paramref name="self"/>
     /// to value of limited in length, with optional suffix
     /// string, by trimming the original string from right.
     /// </summary>
-    /// <param name="str">Value of the parameter.</param>
+    /// <param name="self">Value of the parameter.</param>
     /// <param name="trim">Defines maximum length of
     ///     the returned value together with <paramref name="fuzziness"/>,
     ///     i.e. the returned value length will not be longer than
@@ -23,50 +36,192 @@ public static class StringExtensions
     /// <param name="suffix">Optional suffix to use to indicate
     ///     trimmed part, if set to default <see langword="null"/>
     ///     the ellipsis "..." will be used.</param>
-    /// <returns>String representation of shortened <paramref name="str"/>.</returns>
+    /// <returns>String representation of shortened <paramref name="self"/>.</returns>
     /// <exception cref="ArgumentNullException">Thrown if required arguments
-    ///     are <see langword="null" />.</exception>
+    ///     is <see langword="null" />.</exception>
     /// <exception cref="ArgumentOutOfRangeException">Thrown
     ///     if <paramref name="trim"/> is zero,
     ///     or if suffix is longer than maximum length
     ///     of the returned value.</exception>
     public static string Ellipsis(
-            this string str,
+            this string self,
             ushort trim = 24,
             ushort fuzziness = 6,
             string? suffix = null)
     {
-        Ensure.Param<string>(str).Done();
+        return self.EllipsisWithModifier(
+                trim: trim,
+                fuzziness: fuzziness,
+                suffix: suffix);
+    }
+
+    /// <summary>
+    /// Convert given <paramref name="self"/>
+    /// to value of limited in length for purpose of trully representing
+    /// the original value. Unlike <see cref="Ellipsis(string, ushort, ushort, string?)"/>
+    /// this method shows omitted lenght and is less visually pleasing.
+    /// Trading visual for authenticity.
+    /// </summary>
+    /// <param name="self">Value of the parameter.</param>
+    /// <param name="trim">Defines maximum length of
+    ///     the returned value together with <paramref name="fuzziness"/>,
+    ///     i.e. the returned value length will not be longer than
+    ///     <paramref name="trim"/> plus <paramref name="fuzziness"/>.</param>
+    /// <param name="fuzziness">Fuzziness factor to use in order
+    ///     not to trim.</param>
+    /// <returns>String representation of shortened <paramref name="self"/>
+    /// whoch is either original string if short or form like:
+    /// "original string head[+N more]" where N stands for character count.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if required arguments
+    ///     is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown
+    ///     if <paramref name="trim"/> is zero.</exception>
+    public static string Snippet(
+            this string self,
+            ushort trim = 128,
+            ushort fuzziness = 6)
+    {
+        return self.SnippetWithModifier(
+                trim: trim,
+                fuzziness: fuzziness);
+    }
+
+    /// <summary>
+    /// Convert given <paramref name="self"/>
+    /// to value of limited in length for purpose of trully representing
+    /// the original value as literal. Unlike <see cref="Ellipsis(string, ushort, ushort, string?)"/>
+    /// this method shows omitted lenght and is less visually pleasing.
+    /// Trading visual for authenticity.
+    /// </summary>
+    /// <param name="self">Value of the parameter.</param>
+    /// <param name="trim">Defines maximum length of
+    ///     the returned value before converting to litera
+    ///     together with <paramref name="fuzziness"/>,
+    ///     i.e. the returned value character count length will not be longer than
+    ///     <paramref name="trim"/> plus <paramref name="fuzziness"/>.</param>
+    /// <param name="fuzziness">Fuzziness factor to use in order
+    ///     not to trim.</param>
+    /// <param name="literalDefinition">Definition
+    ///     of the string literal to use,
+    ///     defaults to conservative C like string literal.</param>
+    /// <returns>String representation of shortened <paramref name="self"/>
+    /// whoch is either original string if short or form like:
+    /// '"original string head"[+N more]' where N stands for character count.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if required arguments
+    ///     is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown
+    ///     if <paramref name="trim"/> is zero.</exception>
+    public static string SnippetLiteral(
+            this string self,
+            ushort trim = 128,
+            ushort fuzziness = 6,
+            IStringLiteralDefinition? literalDefinition = null)
+    {
+        return self.SnippetWithModifier(
+                trim: trim,
+                fuzziness: fuzziness,
+                modifier: h => Dump.Literal(h, literalDefinition: literalDefinition));
+    }
+
+    private static string EllipsisWithModifier(
+            this string self,
+            ushort trim = 24,
+            ushort fuzziness = 6,
+            string? suffix = null,
+            Func<string, string>? modifier = null)
+    {
+        Ensure.Param<string>(self).Done();
 
         Ensure.Param(trim)
                 .StrictlyPositive().Done();
 
         int max = trim + fuzziness;
+        modifier ??= h => h;
 
         suffix = Ensure.Optional(suffix)
                 .InRange(0, max)
                 .ValueOr("...");
 
-        if (str.Length <= max)
+        if (self.Length <= max)
         {
-            return str;
+            return modifier(self);
         }
         else if (trim > suffix.Length)
         {
             // suffix fits in trim length
-            return str[..(trim - suffix.Length)] + suffix;
+            return modifier(self[..(trim - suffix.Length)]) + suffix;
         }
         else if (max >= suffix.Length)
         {
             // suffix is long compared to trim length
-            return str[..(max - suffix.Length)] + suffix;
+            return modifier(self[..(max - suffix.Length)]) + suffix;
         }
         else
         {
             // default suffix is way too long compared to trim length
             suffix = new string('.', max - 1);
 
-            return str[..1] + suffix;
+            return modifier(self[..1]) + suffix;
         }
+    }
+
+    private static string SnippetWithModifier(
+            this string self,
+            ushort trim = 128,
+            ushort fuzziness = 6,
+            Func<string, string>? modifier = null)
+    {
+        Ensure.Param<string>(self).Done();
+
+        Ensure.Param(trim)
+                .StrictlyPositive().Done();
+
+        int max = trim + fuzziness;
+
+        if (self.Length <= max)
+        {
+            if (modifier is null)
+            {
+                return self;
+            }
+
+            return modifier(self);
+        }
+
+        foreach ((string start, string stop) in OmissionAttempts)
+        {
+            int numbersLength = Math.Min(
+                    (self.Length - trim).ToString(CultureInfo.InvariantCulture).Length,
+                    self.Length.ToString(CultureInfo.InvariantCulture).Length);
+            int tailLength = start.Length + numbersLength + stop.Length;
+
+            if (tailLength <= trim)
+            {
+                int headLength = trim - tailLength;
+                string head = self[..headLength];
+
+                if (modifier is not null)
+                {
+                    head = modifier(head);
+                }
+
+                string tail = $"{start}{self.Length - headLength}{stop}";
+
+                return head + tail;
+            }
+        }
+
+        string suffix = OmissionEllipsisSuffix;
+
+        if (suffix.Length > max)
+        {
+            suffix = suffix[..max];
+        }
+
+        return self.EllipsisWithModifier(
+                trim: trim,
+                fuzziness: fuzziness,
+                suffix: suffix,
+                modifier: modifier);
     }
 }

--- a/src/Radicle.Common/tests/Radicle.Common.Tests/Check/Models/DictionaryParamTest.cs
+++ b/src/Radicle.Common/tests/Radicle.Common.Tests/Check/Models/DictionaryParamTest.cs
@@ -287,7 +287,7 @@ public class DictionaryParamTest
                     .AllKeys(v => Ensure.Param(v).InRange(1, 1)));
 
         Assert.StartsWith(
-                "Dictionary parameter 'testDict' at key [bc], key error: Parameter 'v' with value: 'bc' length must be in range [1, 1] (Parameter 'v')",
+                "Dictionary parameter 'testDict' at key [bc], key error: Parameter 'v' with value: \"bc\" length must be in range [1, 1] (Parameter 'v')",
                 exc.Message,
                 StringComparison.Ordinal);
     }
@@ -307,7 +307,7 @@ public class DictionaryParamTest
                     .AllKeys(v => Ensure.Param(v).That(v => v != "c")));
 
         Assert.Equal(
-                "Dictionary parameter 'testDict' at key [c], key error: Parameter 'v' with value: 'c' is not valid. (Parameter 'v')",
+                "Dictionary parameter 'testDict' at key [c], key error: Parameter 'v' with value: \"c\" is not valid. (Parameter 'v')",
                 exc.Message);
     }
 }

--- a/src/Radicle.Common/tests/Radicle.Common.Tests/Check/Models/StringParamTest.cs
+++ b/src/Radicle.Common/tests/Radicle.Common.Tests/Check/Models/StringParamTest.cs
@@ -2,6 +2,7 @@ namespace Radicle.Common.Check.Models;
 
 using System;
 using Moq;
+using Radicle.Common.Extensions;
 using Xunit;
 
 public class StringParamTest
@@ -102,7 +103,7 @@ public class StringParamTest
                 () => Ensure.Param(input).NotWhiteSpace());
 
         Assert.StartsWith(
-                $"Parameter 'input' with value: '{input}' cannot be a white space string.",
+                $"Parameter 'input' with value: {Dump.Literal(input)} cannot be a white space string.",
                 exc.Message,
                 StringComparison.Ordinal);
     }
@@ -143,7 +144,7 @@ public class StringParamTest
                 () => Ensure.Param(input).NoNewLines());
 
         Assert.StartsWith(
-                $"Parameter 'input' with value: '{input}' cannot be a string with new lines.",
+                $"Parameter 'input' with value: {Dump.Literal(input)} cannot be a string with new lines.",
                 exc.Message,
                 StringComparison.Ordinal);
     }
@@ -181,7 +182,22 @@ public class StringParamTest
         string range = Dump.Range(min, max, includeLower: lower, includeUpper: upper);
 
         Assert.StartsWith(
-                $"Parameter 'input' with value: '{input}' length must be in range {range}",
+                $"Parameter 'input' with value: {Dump.Literal(input)} length must be in range {range}",
+                exc.Message,
+                StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void InRange_InvalidLongParam_Throws()
+    {
+        string input = new('a', 160);
+        ArgumentOutOfRangeException exc = Assert.Throws<ArgumentOutOfRangeException>(
+                () => Ensure.Param(input).InRange(1, 24));
+
+        string range = Dump.Range(1, 24);
+
+        Assert.StartsWith(
+                $"Parameter 'input' with value: {input.SnippetLiteral()} length must be in range {range}",
                 exc.Message,
                 StringComparison.Ordinal);
     }
@@ -204,7 +220,7 @@ public class StringParamTest
                 () => Ensure.Param(input).IsRegex());
 
         Assert.StartsWith(
-                $"Parameter 'input' with value: '{input}' must be a valid regex.",
+                $"Parameter 'input' with value: {Dump.Literal(input)} must be a valid regex.",
                 exc.Message,
                 StringComparison.Ordinal);
     }

--- a/src/Radicle.Common/tests/Radicle.Common.Tests/Check/Models/StringParamTest.cs
+++ b/src/Radicle.Common/tests/Radicle.Common.Tests/Check/Models/StringParamTest.cs
@@ -118,6 +118,12 @@ public class StringParamTest
         Ensure.Param(input).NoNewLines();
     }
 
+    [Fact]
+    public void NoNewLines_LongParam_Works()
+    {
+        Ensure.Param(new string('x', 17_000)).NoNewLines();
+    }
+
     [Theory]
     [InlineData("\n")]
     [InlineData("\r")]

--- a/src/Radicle.Common/tests/Radicle.Common.Tests/Extensions/StringExtensionsTest.cs
+++ b/src/Radicle.Common/tests/Radicle.Common.Tests/Extensions/StringExtensionsTest.cs
@@ -1,6 +1,7 @@
 namespace Radicle.Common.Extensions;
 
 using System;
+using Radicle.Common.Tokenization;
 using Xunit;
 
 public class StringExtensionsTest
@@ -48,10 +49,169 @@ public class StringExtensionsTest
     {
         const string str = "Red brown fox jumped";
 
+        string actual = str.Ellipsis(
+                    trim: trim,
+                    fuzziness: fuziness);
+
         Assert.Equal(
                 expected,
-                str.Ellipsis(
+                actual);
+    }
+
+    [Fact]
+    public void Snippet_NullInput_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => ((string)null!).Snippet());
+    }
+
+    [Fact]
+    public void Snippet_NonPositiveTrim_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => string.Empty.Snippet(trim: 0));
+    }
+
+    /*
+     "Red brown fox jumped"
+      123456789_123456789_
+      _987654321_987654321
+     */
+    [Theory]
+    [InlineData("Red brown fox jumped", 18, 2)]
+    [InlineData("Red brown[+11 more]", 18, 1)]
+    [InlineData("Red brown[+11 more]", 18, 0)]
+    [InlineData("Red brown fox jumped", 1, 19)]
+    [InlineData("Red[+17]", 8, 0)]
+    [InlineData("[", 1, 0)]
+    [InlineData("[+", 1, 1)]
+    [InlineData("[+]", 2, 1)]
+    [InlineData("R[+]", 1, 3)]
+    [InlineData("Red[+]", 1, 5)]
+    [InlineData("Red [+]", 1, 6)]
+    [InlineData("R[+]", 3, 1)]
+    [InlineData("[+20]", 5, 1)]
+    [InlineData("R[+19]", 6, 1)]
+    [InlineData("Re[+18]", 7, 1)]
+    public void Snippet_Works(
+            string expected,
+            ushort trim,
+            ushort fuziness)
+    {
+        const string str = "Red brown fox jumped";
+
+        string actual = str.Snippet(
                     trim: trim,
-                    fuzziness: fuziness));
+                    fuzziness: fuziness);
+
+        Assert.Equal(
+                expected,
+                actual);
+    }
+
+    [Fact]
+    public void SnippetLiteral_NullInput_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => ((string)null!).SnippetLiteral());
+    }
+
+    [Fact]
+    public void SnippetLiteral_NonPositiveTrim_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => string.Empty.SnippetLiteral(trim: 0));
+    }
+
+    /*
+     "Red brown fox jumped"
+      123456789_123456789_
+      _987654321_987654321
+     */
+    [Theory]
+    [InlineData("\"Red brown fox jumped\"", 18, 2)]
+    [InlineData("\"Red brown\"[+11 more]", 18, 1)]
+    [InlineData("\"Red brown\"[+11 more]", 18, 0)]
+    [InlineData("\"Red brown fox jumped\"", 1, 19)]
+    [InlineData("\"Red\"[+17]", 8, 0)]
+    [InlineData("\"\"[", 1, 0)]
+    [InlineData("\"\"[+", 1, 1)]
+    [InlineData("\"\"[+]", 2, 1)]
+    [InlineData("\"R\"[+]", 1, 3)]
+    [InlineData("\"Red\"[+]", 1, 5)]
+    [InlineData("\"Red \"[+]", 1, 6)]
+    [InlineData("\"R\"[+]", 3, 1)]
+    [InlineData("\"\"[+20]", 5, 1)]
+    [InlineData("\"R\"[+19]", 6, 1)]
+    [InlineData("\"Re\"[+18]", 7, 1)]
+    public void SnippetLiteral_Works(
+            string expected,
+            ushort trim,
+            ushort fuziness)
+    {
+        const string str = "Red brown fox jumped";
+
+        string actual = str.SnippetLiteral(
+                    trim: trim,
+                    fuzziness: fuziness);
+
+        Assert.Equal(
+                expected,
+                actual);
+    }
+
+    [Theory]
+    [InlineData("\"R\\xc3\\xabd brow\\n\"[+11 more]", 18, 1)]
+    [InlineData("\"R\\xc3\\xabd brow\\n fox'jumped\"", 1, 19)]
+    public void SnippetLiteral_InputWithEscapeConservative_Works(
+            string expected,
+            ushort trim,
+            ushort fuziness)
+    {
+        const string str = "R\u00EBd brow\n fox\'jumped";
+
+        string actual = str.SnippetLiteral(
+                    trim: trim,
+                    fuzziness: fuziness);
+
+        Assert.Equal(
+                expected,
+                actual);
+    }
+
+    [Theory]
+    [InlineData("\"R\u00EBd brow\\n\"[+11 more]", 18, 1)]
+    [InlineData("\"R\u00EBd brow\\n fox'jumped\"", 1, 19)]
+    public void SnippetLiteral_InputWithEscapeNormal_Works(
+            string expected,
+            ushort trim,
+            ushort fuziness)
+    {
+        const string str = "R\u00EBd brow\n fox\'jumped";
+
+        string actual = str.SnippetLiteral(
+                    trim: trim,
+                    fuzziness: fuziness,
+                    literalDefinition: CLikeStringLiteralDefinition.Normal);
+
+        Assert.Equal(
+                expected,
+                actual);
+    }
+
+    [Theory]
+    [InlineData("\"R\u00EBd brow\n\"[+11 more]", 18, 1)]
+    [InlineData("\"R\u00EBd brow\n fox'jumped\"", 1, 19)]
+    public void SnippetLiteral_InputWithEscapeMinimal_Works(
+            string expected,
+            ushort trim,
+            ushort fuziness)
+    {
+        const string str = "R\u00EBd brow\n fox\'jumped";
+
+        string actual = str.SnippetLiteral(
+                    trim: trim,
+                    fuzziness: fuziness,
+                    literalDefinition: CLikeStringLiteralDefinition.Minimal);
+
+        Assert.Equal(
+                expected,
+                actual);
     }
 }


### PR DESCRIPTION
- Fix bug preventing correct validation of long strings for no new lines
- Clarify use of base disposable class in documentation
- Add new Snippet end `SnippetLiteral` extension. Their are more suited for trimmed string value dumps